### PR TITLE
feat: add working FastAPI backend with simulator and REST API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,5 @@ svc/data/*.json
 svc/.venv/
 svc/.env
 
+# Visual Studio local settings
+.vs/

--- a/svc/README.md
+++ b/svc/README.md
@@ -1,9 +1,24 @@
-# Control service skeleton
+# Control service
 
-Planned modules
-- command queue
-- retry policy
-- safety guard  min dwell times and rate limiting
-- adapter for real hardware or simulator
+What this gives you today
+- Lists panels and groups
+- Sets tint level for a single panel or a group
+- Enforces dwell time per panel
+- Writes an audit log to `svc/data/audit.json`
+- Simulator by default and a stub for real hardware
 
-No code yet  will be added after API validation
+## Setup
+
+Python 3.11 or newer
+
+```bash
+cd svc
+python -m venv .venv
+# Windows
+. .venv/Scripts/activate
+# macOS or Linux
+# source .venv/bin/activate
+
+pip install --upgrade pip
+pip install -r requirements.txt
+python main.py

--- a/svc/app/adapter.py
+++ b/svc/app/adapter.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from typing import List
+from .models import Panel, Group, TintLevel
+
+class RealAdapter:
+    """
+    Placeholder for the real trailer integration.
+    Implement these methods once the local API is validated.
+    """
+    def list_panels(self) -> List[Panel]:
+        raise NotImplementedError("real adapter not implemented yet")
+
+    def list_groups(self) -> List[Group]:
+        raise NotImplementedError("real adapter not implemented yet")
+
+    def set_panel(self, panel_id: str, level: TintLevel, min_dwell: int) -> bool:
+        raise NotImplementedError("real adapter not implemented yet")
+
+    def set_group(self, group_id: str, level: TintLevel, min_dwell: int) -> List[str]:
+        raise NotImplementedError("real adapter not implemented yet")

--- a/svc/app/config.py
+++ b/svc/app/config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+import os
+
+# Service mode: "sim" for the built in simulator or "real" for the trailer adapter
+MODE = os.getenv("SVC_MODE", "sim").lower()
+
+# Minimum seconds between level changes per panel
+MIN_DWELL_SECONDS = int(os.getenv("SVC_MIN_DWELL_SECONDS", "20"))
+
+# Path for durable state and audit log
+DATA_DIR = os.getenv("SVC_DATA_DIR", "data")
+PANELS_FILE = os.path.join("svc", DATA_DIR, "panels.json")
+AUDIT_FILE = os.path.join("svc", DATA_DIR, "audit.json")

--- a/svc/app/models.py
+++ b/svc/app/models.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from typing import List, Optional, Literal, Dict
+from pydantic import BaseModel, Field, conint
+
+TintLevel = conint(ge=0, le=100)
+
+class Panel(BaseModel):
+    id: str
+    name: str
+    group_id: Optional[str] = None
+    level: TintLevel = 0
+    last_change_ts: float = 0.0
+
+class Group(BaseModel):
+    id: str
+    name: str
+    member_ids: List[str] = Field(default_factory=list)
+
+class CommandRequest(BaseModel):
+    target_type: Literal["panel", "group"]
+    target_id: str
+    level: TintLevel
+
+class CommandResult(BaseModel):
+    ok: bool
+    applied_to: List[str]
+    message: str = ""
+
+class Snapshot(BaseModel):
+    panels: Dict[str, Panel] = Field(default_factory=dict)
+    groups: Dict[str, Group] = Field(default_factory=dict)
+
+class AuditEntry(BaseModel):
+    ts: float
+    actor: str
+    target_type: str
+    target_id: str
+    level: int
+    applied_to: List[str]
+    result: str

--- a/svc/app/routes.py
+++ b/svc/app/routes.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException, Depends
+from typing import List
+from .models import Panel, Group, CommandRequest, CommandResult
+from .service import ControlService
+from .config import MODE
+
+router = APIRouter()
+svc: ControlService | None = None
+
+def get_service() -> ControlService:
+    global svc
+    if svc is None:
+        svc = ControlService()
+    return svc
+
+@router.get("/health")
+def health():
+    return {"status": "ok", "mode": MODE}
+
+@router.get("/panels", response_model=List[Panel])
+def list_panels(service: ControlService = Depends(get_service)) -> List[Panel]:
+    return service.list_panels()
+
+@router.get("/groups", response_model=List[Group])
+def list_groups(service: ControlService = Depends(get_service)) -> List[Group]:
+    return service.list_groups()
+
+@router.post("/commands/set-level", response_model=CommandResult)
+def set_level(body: CommandRequest, service: ControlService = Depends(get_service)) -> CommandResult:
+    if body.target_type == "panel":
+        ok, applied, msg = service.set_panel_level(body.target_id, body.level)
+    else:
+        ok, applied, msg = service.set_group_level(body.target_id, body.level)
+
+    if not ok:
+        if msg in ("panel not found", "group not found"):
+            raise HTTPException(status_code=404, detail=msg)
+        if "dwell" in msg:
+            raise HTTPException(status_code=429, detail=msg)
+        raise HTTPException(status_code=500, detail=msg)
+
+    return CommandResult(ok=True, applied_to=applied, message=msg)

--- a/svc/app/service.py
+++ b/svc/app/service.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+from typing import List, Tuple
+from .models import TintLevel
+from .simulator import Simulator
+from .adapter import RealAdapter
+from .config import MODE, MIN_DWELL_SECONDS
+from .state import audit
+
+class ControlService:
+    def __init__(self) -> None:
+        self.mode = MODE
+        if self.mode == "real":
+            self.backend = RealAdapter()
+        else:
+            self.backend = Simulator()
+
+    # read
+    def list_panels(self):
+        return self.backend.list_panels()
+
+    def list_groups(self):
+        return self.backend.list_groups()
+
+    # write
+    def set_panel_level(self, panel_id: str, level: TintLevel, actor: str = "api") -> Tuple[bool, List[str], str]:
+        try:
+            ok = self.backend.set_panel(panel_id, level, MIN_DWELL_SECONDS)
+            if ok:
+                applied = [panel_id]
+                msg = "panel updated"
+            else:
+                applied = []
+                msg = "dwell time not met"
+            audit(actor, "panel", panel_id, int(level), applied, msg)
+            return ok, applied, msg
+        except KeyError:
+            return False, [], "panel not found"
+
+    def set_group_level(self, group_id: str, level: TintLevel, actor: str = "api") -> Tuple[bool, List[str], str]:
+        try:
+            applied = self.backend.set_group(group_id, level, MIN_DWELL_SECONDS)
+            ok = len(applied) > 0
+            msg = "group updated" if ok else "no panels updated due to dwell time"
+            audit(actor, "group", group_id, int(level), applied, msg)
+            return ok, applied, msg
+        except KeyError:
+            return False, [], "group not found"

--- a/svc/app/simulator.py
+++ b/svc/app/simulator.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import time
+from typing import Dict, List
+from .models import Panel, Group, TintLevel, Snapshot
+from .state import load_snapshot, save_snapshot
+
+class Simulator:
+    def __init__(self) -> None:
+        # load from disk so levels persist across restarts
+        self.snap: Snapshot = load_snapshot()
+        if not self.snap.panels:
+            # caller should have bootstrapped but keep safe
+            pass
+
+    def list_panels(self) -> List[Panel]:
+        return list(self.snap.panels.values())
+
+    def list_groups(self) -> List[Group]:
+        return list(self.snap.groups.values())
+
+    def _can_change(self, p: Panel, min_dwell: int) -> bool:
+        return (time.time() - p.last_change_ts) >= min_dwell
+
+    def set_panel(self, panel_id: str, level: TintLevel, min_dwell: int) -> bool:
+        if panel_id not in self.snap.panels:
+            raise KeyError(panel_id)
+        p = self.snap.panels[panel_id]
+        if not self._can_change(p, min_dwell):
+            return False
+        p.level = int(level)
+        p.last_change_ts = time.time()
+        save_snapshot(self.snap)
+        return True
+
+    def set_group(self, group_id: str, level: TintLevel, min_dwell: int) -> List[str]:
+        if group_id not in self.snap.groups:
+            raise KeyError(group_id)
+        applied: List[str] = []
+        for pid in self.snap.groups[group_id].member_ids:
+            ok = self.set_panel(pid, level, min_dwell)
+            if ok:
+                applied.append(pid)
+        return applied

--- a/svc/app/state.py
+++ b/svc/app/state.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import json
+import os
+import time
+from typing import Dict, List
+from .models import Panel, Group, Snapshot, AuditEntry
+from .config import PANELS_FILE, AUDIT_FILE
+
+def _ensure_dirs() -> None:
+    os.makedirs(os.path.dirname(PANELS_FILE), exist_ok=True)
+    os.makedirs(os.path.dirname(AUDIT_FILE), exist_ok=True)
+
+def load_snapshot() -> Snapshot:
+    _ensure_dirs()
+    if not os.path.exists(PANELS_FILE):
+        return Snapshot()
+    with open(PANELS_FILE, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    panels = {k: Panel(**v) for k, v in data.get("panels", {}).items()}
+    groups = {k: Group(**v) for k, v in data.get("groups", {}).items()}
+    return Snapshot(panels=panels, groups=groups)
+
+def save_snapshot(s: Snapshot) -> None:
+    _ensure_dirs()
+    data = {
+        "panels": {k: v.model_dump() for k, v in s.panels.items()},
+        "groups": {k: v.model_dump() for k, v in s.groups.items()},
+    }
+    with open(PANELS_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+def append_audit(entry: AuditEntry) -> None:
+    _ensure_dirs()
+    row = entry.model_dump()
+    # write one JSON per line for easy tailing
+    with open(AUDIT_FILE, "a", encoding="utf-8") as f:
+        f.write(json.dumps(row) + "\n")
+
+def bootstrap_default_if_empty() -> Snapshot:
+    snap = load_snapshot()
+    if snap.panels:
+        return snap
+    # seed 20 facade panels and 2 skylights
+    for i in range(1, 21):
+        pid = f"P{i:02d}"
+        snap.panels[pid] = Panel(id=pid, name=f"Facade {i}", group_id="G-facade")
+    snap.panels["SK1"] = Panel(id="SK1", name="Skylight 1", group_id="G-skylights")
+    snap.panels["SK2"] = Panel(id="SK2", name="Skylight 2", group_id="G-skylights")
+    snap.groups["G-facade"] = Group(
+        id="G-facade",
+        name="Facade",
+        member_ids=[f"P{i:02d}" for i in range(1, 21)],
+    )
+    snap.groups["G-skylights"] = Group(
+        id="G-skylights",
+        name="Skylights",
+        member_ids=["SK1", "SK2"],
+    )
+    save_snapshot(snap)
+    return snap
+
+def audit(actor: str, target_type: str, target_id: str, level: int, applied: List[str], result: str) -> None:
+    append_audit(AuditEntry(
+        ts=time.time(),
+        actor=actor,
+        target_type=target_type,
+        target_id=target_id,
+        level=level,
+        applied_to=applied,
+        result=result,
+    ))

--- a/svc/main.py
+++ b/svc/main.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+import uvicorn
+from fastapi import FastAPI
+from app.routes import router
+from app.state import bootstrap_default_if_empty
+
+def create_app() -> FastAPI:
+    # ensure seed data exists for the simulator on first run
+    bootstrap_default_if_empty()
+    app = FastAPI(title="ECG Control Service", version="0.1.0")
+    app.include_router(router)
+    return app
+
+app = create_app()
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/svc/requirements.txt
+++ b/svc/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.5
+uvicorn==0.32.1
+pydantic==2.9.2
+httpx==0.27.2
+pytest==8.3.3

--- a/svc/svc/data/audit.json
+++ b/svc/svc/data/audit.json
@@ -1,0 +1,1 @@
+{"ts": 1760726759.5898983, "actor": "api", "target_type": "panel", "target_id": "P01", "level": 50, "applied_to": ["P01"], "result": "panel updated"}

--- a/svc/svc/data/panels.json
+++ b/svc/svc/data/panels.json
@@ -1,0 +1,194 @@
+{
+  "panels": {
+    "P01": {
+      "id": "P01",
+      "name": "Facade 1",
+      "group_id": "G-facade",
+      "level": 50,
+      "last_change_ts": 1760726759.5898983
+    },
+    "P02": {
+      "id": "P02",
+      "name": "Facade 2",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P03": {
+      "id": "P03",
+      "name": "Facade 3",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P04": {
+      "id": "P04",
+      "name": "Facade 4",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P05": {
+      "id": "P05",
+      "name": "Facade 5",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P06": {
+      "id": "P06",
+      "name": "Facade 6",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P07": {
+      "id": "P07",
+      "name": "Facade 7",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P08": {
+      "id": "P08",
+      "name": "Facade 8",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P09": {
+      "id": "P09",
+      "name": "Facade 9",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P10": {
+      "id": "P10",
+      "name": "Facade 10",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P11": {
+      "id": "P11",
+      "name": "Facade 11",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P12": {
+      "id": "P12",
+      "name": "Facade 12",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P13": {
+      "id": "P13",
+      "name": "Facade 13",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P14": {
+      "id": "P14",
+      "name": "Facade 14",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P15": {
+      "id": "P15",
+      "name": "Facade 15",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P16": {
+      "id": "P16",
+      "name": "Facade 16",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P17": {
+      "id": "P17",
+      "name": "Facade 17",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P18": {
+      "id": "P18",
+      "name": "Facade 18",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P19": {
+      "id": "P19",
+      "name": "Facade 19",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "P20": {
+      "id": "P20",
+      "name": "Facade 20",
+      "group_id": "G-facade",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "SK1": {
+      "id": "SK1",
+      "name": "Skylight 1",
+      "group_id": "G-skylights",
+      "level": 0,
+      "last_change_ts": 0.0
+    },
+    "SK2": {
+      "id": "SK2",
+      "name": "Skylight 2",
+      "group_id": "G-skylights",
+      "level": 0,
+      "last_change_ts": 0.0
+    }
+  },
+  "groups": {
+    "G-facade": {
+      "id": "G-facade",
+      "name": "Facade",
+      "member_ids": [
+        "P01",
+        "P02",
+        "P03",
+        "P04",
+        "P05",
+        "P06",
+        "P07",
+        "P08",
+        "P09",
+        "P10",
+        "P11",
+        "P12",
+        "P13",
+        "P14",
+        "P15",
+        "P16",
+        "P17",
+        "P18",
+        "P19",
+        "P20"
+      ]
+    },
+    "G-skylights": {
+      "id": "G-skylights",
+      "name": "Skylights",
+      "member_ids": [
+        "SK1",
+        "SK2"
+      ]
+    }
+  }
+}

--- a/svc/tests/test_basic.py
+++ b/svc/tests/test_basic.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+def test_list_panels_groups():
+    r1 = client.get("/panels")
+    r2 = client.get("/groups")
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    panels = r1.json()
+    groups = r2.json()
+    # 22 total: 20 facade and 2 skylights
+    assert len(panels) == 22
+    assert any(g["id"] == "G-facade" for g in groups)
+
+def test_set_and_dwell():
+    # first change should succeed
+    r = client.post("/commands/set-level", json={"target_type": "panel", "target_id": "P01", "level": 40})
+    assert r.status_code == 200
+    # immediate second change should throttle by dwell guard
+    r2 = client.post("/commands/set-level", json={"target_type": "panel", "target_id": "P01", "level": 70})
+    assert r2.status_code == 429


### PR DESCRIPTION
feat: add working FastAPI backend with simulator and REST API

- Added full backend skeleton under svc/ using FastAPI and Uvicorn
- Includes simulator for 20 facade panels + 2 skylights
- Supports listing panels/groups and setting tint levels
- Enforces dwell-time safety between tint changes
- Writes audit log and persists state to svc/data/
- Added tests, requirements.txt, and CI workflow for lint/tests
- Ready for connection to real trailer API (adapter.py placeholder)
