### PR TITLE
Add Customizable Group Layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,4 @@ svc/data/jeti_sim_output/
 # Local temporary research repo / scratch workspace
 /.tmp_luox/
 svc/data/jeti_sim_output
+

--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ svc/data/jeti_sim_output/
 
 # Local temporary research repo / scratch workspace
 /.tmp_luox/
+svc/data/jeti_sim_output

--- a/svc/app/adapter.py
+++ b/svc/app/adapter.py
@@ -3,7 +3,8 @@ import os
 import time
 import logging
 from typing import Any, List, Dict, Optional
-from .models import Panel, Group, TintLevel
+from .group_layout import normalize_group_layout
+from .models import Panel, Group, GroupLayout, TintLevel
 from .config import (
     HALIO_API_URL,
     HALIO_API_KEY,
@@ -446,7 +447,7 @@ class RealAdapter:
         """
         return self._send_group_tint(group_id, level)
 
-    def create_group(self, name: str, member_ids: List[str]) -> Group:
+    def create_group(self, name: str, member_ids: List[str], layout: GroupLayout | None = None) -> Group:
         created = self._create_group_request(name, member_ids)
         if not created:
             raise RuntimeError("failed to create Halio group")
@@ -466,4 +467,5 @@ class RealAdapter:
             id=group_id,
             name=created.get("name", name),
             member_ids=member_ids,
+            layout=normalize_group_layout(member_ids, layout),
         )

--- a/svc/app/group_layout.py
+++ b/svc/app/group_layout.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Mapping, Optional, Sequence
+
+from .models import GroupLayout, GroupLayoutDivider, GroupLayoutDividers, GroupLayoutItem
+
+DEFAULT_GROUP_LAYOUT_COLUMNS = 4
+MAX_GROUP_LAYOUT_COLUMNS = 8
+
+
+def _unique_member_ids(member_ids: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    unique_ids: List[str] = []
+    for panel_id in member_ids:
+        if not isinstance(panel_id, str):
+            continue
+        normalized = panel_id.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique_ids.append(normalized)
+    return unique_ids
+
+
+def _normalize_positive_int(value: object) -> Optional[int]:
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _unique_dividers(
+    dividers: Sequence[GroupLayoutDivider],
+    max_row: int,
+    max_column: int,
+) -> List[GroupLayoutDivider]:
+    if max_row < 1 or max_column < 1:
+        return []
+
+    seen: set[tuple[int, int]] = set()
+    result: List[GroupLayoutDivider] = []
+    for divider in dividers:
+        row = _normalize_positive_int(divider.row)
+        column = _normalize_positive_int(divider.column)
+        if row is None or column is None:
+            continue
+        if row > max_row or column > max_column:
+            continue
+        key = (row, column)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(GroupLayoutDivider(row=row, column=column))
+
+    return sorted(result, key=lambda divider: (divider.row, divider.column))
+
+
+def _normalize_dividers(
+    dividers: Optional[GroupLayoutDividers],
+    rows: int,
+    columns: int,
+) -> Optional[GroupLayoutDividers]:
+    if dividers is None:
+        return None
+
+    vertical = _unique_dividers(dividers.vertical, rows, columns - 1)
+    horizontal = _unique_dividers(dividers.horizontal, rows - 1, columns)
+    if not vertical and not horizontal:
+        return None
+
+    return GroupLayoutDividers(vertical=vertical, horizontal=horizontal)
+
+
+def build_default_group_layout(
+    member_ids: Sequence[str],
+    columns: int = DEFAULT_GROUP_LAYOUT_COLUMNS,
+) -> Optional[GroupLayout]:
+    unique_ids = _unique_member_ids(member_ids)
+    if not unique_ids:
+        return None
+
+    normalized_columns = max(1, min(MAX_GROUP_LAYOUT_COLUMNS, int(columns or DEFAULT_GROUP_LAYOUT_COLUMNS)))
+    items: List[GroupLayoutItem] = []
+    for index, panel_id in enumerate(unique_ids):
+        row = (index // normalized_columns) + 1
+        column = (index % normalized_columns) + 1
+        items.append(GroupLayoutItem(panel_id=panel_id, row=row, column=column))
+    return GroupLayout(columns=normalized_columns, items=items)
+
+
+def normalize_group_layout(
+    member_ids: Sequence[str],
+    layout: Optional[GroupLayout | Mapping[str, object]],
+) -> Optional[GroupLayout]:
+    unique_ids = _unique_member_ids(member_ids)
+    if not unique_ids:
+        return None
+
+    if layout is None:
+        return build_default_group_layout(unique_ids)
+
+    if not isinstance(layout, GroupLayout):
+        layout = GroupLayout.model_validate(layout)
+
+    columns = max(1, min(MAX_GROUP_LAYOUT_COLUMNS, int(layout.columns or DEFAULT_GROUP_LAYOUT_COLUMNS)))
+    valid_ids = set(unique_ids)
+    taken_positions: set[tuple[int, int]] = set()
+    positions_by_panel: dict[str, tuple[int, int]] = {}
+
+    for item in layout.items:
+        panel_id = item.panel_id.strip()
+        if panel_id not in valid_ids or panel_id in positions_by_panel:
+            continue
+
+        row = max(1, int(item.row))
+        column = max(1, min(columns, int(item.column)))
+        while (row, column) in taken_positions:
+            column += 1
+            if column > columns:
+                column = 1
+                row += 1
+
+        positions_by_panel[panel_id] = (row, column)
+        taken_positions.add((row, column))
+
+    next_row = 1
+    next_column = 1
+
+    def next_available_position() -> tuple[int, int]:
+        nonlocal next_row, next_column
+        while (next_row, next_column) in taken_positions:
+            next_column += 1
+            if next_column > columns:
+                next_column = 1
+                next_row += 1
+        taken_positions.add((next_row, next_column))
+        return next_row, next_column
+
+    items: List[GroupLayoutItem] = []
+    for panel_id in unique_ids:
+        row, column = positions_by_panel.get(panel_id, next_available_position())
+        items.append(GroupLayoutItem(panel_id=panel_id, row=row, column=column))
+
+    minimum_rows = max(1, (len(unique_ids) + columns - 1) // columns, *(item.row for item in items))
+    explicit_rows = _normalize_positive_int(layout.rows)
+    rows = max(minimum_rows, explicit_rows or minimum_rows)
+    dividers = _normalize_dividers(layout.dividers, rows, columns)
+
+    return GroupLayout(
+        columns=columns,
+        rows=rows if explicit_rows is not None and rows > minimum_rows else None,
+        items=items,
+        dividers=dividers,
+    )

--- a/svc/app/models.py
+++ b/svc/app/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import List, Optional, Literal, Dict
-from pydantic import BaseModel, Field, conint
+from pydantic import BaseModel, Field, conint, model_serializer
 
 TintLevel = conint(ge=0, le=100)
 
@@ -13,11 +13,59 @@ class Panel(BaseModel):
     last_change_ts: float = Field(default=0.0, description="Unix timestamp of last level change")
 
 
+class GroupLayoutItem(BaseModel):
+    """Saved 2D position for one panel inside a group layout."""
+    panel_id: str = Field(description="Panel identifier included in the group")
+    row: conint(ge=1) = Field(description="1-based row position in the 2D layout")
+    column: conint(ge=1) = Field(description="1-based column position in the 2D layout")
+
+
+class GroupLayoutDivider(BaseModel):
+    """Saved divider segment inside a group layout."""
+    row: conint(ge=1) = Field(description="1-based row position for the divider segment")
+    column: conint(ge=1) = Field(description="1-based column position for the divider segment")
+
+
+class GroupLayoutDividers(BaseModel):
+    """Saved divider segments for a group layout."""
+    vertical: List[GroupLayoutDivider] = Field(default_factory=list)
+    horizontal: List[GroupLayoutDivider] = Field(default_factory=list)
+
+
+class GroupLayout(BaseModel):
+    """Optional 2D layout metadata for a group."""
+    columns: conint(ge=1) = Field(
+        default=4,
+        description="Preferred number of columns to use when rendering the group layout",
+    )
+    rows: Optional[conint(ge=1)] = Field(
+        default=None,
+        description="Optional persisted row count when the layout includes empty rows",
+    )
+    items: List[GroupLayoutItem] = Field(
+        default_factory=list,
+        description="Saved row/column positions for group member panels",
+    )
+    dividers: Optional[GroupLayoutDividers] = Field(
+        default=None,
+        description="Optional vertical and horizontal dividers for the 2D layout",
+    )
+
+    @model_serializer(mode="wrap")
+    def serialize_without_empty_metadata(self, handler):
+        data = handler(self)
+        return {key: value for key, value in data.items() if value is not None}
+
+
 class Group(BaseModel):
     """Group represents a collection of panels that can be controlled together."""
     id: str = Field(description="Group identifier (e.g., G-facade, G-1)")
     name: str = Field(description="Human-readable group name")
     member_ids: List[str] = Field(default_factory=list, description="List of panel IDs in this group")
+    layout: Optional[GroupLayout] = Field(
+        default=None,
+        description="Optional saved 2D layout for arranging panels in the UI",
+    )
 
 
 class CommandRequest(BaseModel):
@@ -60,12 +108,20 @@ class GroupCreate(BaseModel):
     """Request to create a new group."""
     name: str = Field(description="Name for the new group")
     member_ids: List[str] = Field(default_factory=list, description="Panel IDs to include in the group")
+    layout: Optional[GroupLayout] = Field(
+        default=None,
+        description="Optional saved 2D layout for the group's panels",
+    )
 
 
 class GroupUpdate(BaseModel):
     """Request to update an existing group."""
     name: Optional[str] = Field(default=None, description="New name for the group (optional)")
     member_ids: Optional[List[str]] = Field(default=None, description="New list of panel IDs (optional)")
+    layout: Optional[GroupLayout] = Field(
+        default=None,
+        description="Updated 2D layout for the group's panels (optional)",
+    )
 
 
 class DeleteGroupResponse(BaseModel):

--- a/svc/app/routes.py
+++ b/svc/app/routes.py
@@ -123,7 +123,7 @@ def set_level(
 def create_group(body: GroupCreate, service: ControlService = Depends(get_service)) -> Group:
     """Create a new group."""
     try:
-        return service.create_group(body.name, body.member_ids)
+        return service.create_group(body.name, body.member_ids, body.layout)
     except RuntimeError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -148,7 +148,7 @@ def update_group(
 ) -> Group:
     """Update an existing group."""
     try:
-        return service.update_group(group_id, body.name, body.member_ids)
+        return service.update_group(group_id, body.name, body.member_ids, body.layout)
     except KeyError:
         raise HTTPException(status_code=404, detail="group not found")
     except RuntimeError as e:

--- a/svc/app/service.py
+++ b/svc/app/service.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 import logging
 from typing import List, Tuple
-from .models import TintLevel
+from .models import Group, GroupLayout, TintLevel
 from .simulator import Simulator
 from .adapter import RealAdapter
 from .config import MODE, MIN_DWELL_SECONDS
-from .state import audit, update_panel_state
+from .state import audit, load_groups, save_groups, update_panel_state
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,16 @@ class ControlService:
         return self.backend.list_panels()
 
     def list_groups(self):
-        return self.backend.list_groups()
+        groups = self.backend.list_groups()
+        local_groups = load_groups()
+        merged_groups: list[Group] = []
+        for group in groups:
+            local_group = local_groups.get(group.id)
+            if local_group and local_group.layout is not None:
+                merged_groups.append(group.model_copy(update={"layout": local_group.layout}))
+            else:
+                merged_groups.append(group)
+        return merged_groups
 
     # write
     def set_panel_level(
@@ -77,15 +86,40 @@ class ControlService:
         except KeyError:
             return False, [], "group not found"
 
-    def create_group(self, name: str, member_ids: List[str]):
+    def create_group(self, name: str, member_ids: List[str], layout: GroupLayout | None = None):
         if not hasattr(self.backend, "create_group"):
             raise RuntimeError("group create not supported in this mode")
-        return self.backend.create_group(name, member_ids)
+        group = self.backend.create_group(name, member_ids, layout)
+        if self.mode == "real":
+            local_groups = load_groups()
+            local_groups[group.id] = group
+            save_groups(local_groups)
+        return group
 
-    def update_group(self, group_id: str, name: str | None, member_ids: List[str] | None):
-        if not hasattr(self.backend, "update_group"):
-            raise RuntimeError("group update not supported in this mode")
-        return self.backend.update_group(group_id, name, member_ids)
+    def update_group(
+        self,
+        group_id: str,
+        name: str | None,
+        member_ids: List[str] | None,
+        layout: GroupLayout | None = None,
+    ):
+        if hasattr(self.backend, "update_group"):
+            return self.backend.update_group(group_id, name, member_ids, layout)
+
+        existing = next((group for group in self.backend.list_groups() if group.id == group_id), None)
+        if existing is None:
+            raise KeyError(group_id)
+
+        if (name is not None and name != existing.name) or (
+            member_ids is not None and list(member_ids) != list(existing.member_ids)
+        ):
+            raise RuntimeError("group membership/name updates not supported in this mode")
+
+        updated = existing.model_copy(update={"layout": layout})
+        local_groups = load_groups()
+        local_groups[group_id] = updated
+        save_groups(local_groups)
+        return updated
 
     def delete_group(self, group_id: str) -> bool:
         if not hasattr(self.backend, "delete_group"):

--- a/svc/app/simulator.py
+++ b/svc/app/simulator.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import time
 import threading
 from typing import Dict, List
-from .models import Panel, Group, TintLevel, Snapshot
+from .group_layout import normalize_group_layout
+from .models import Panel, Group, GroupLayout, TintLevel, Snapshot
 from .state import load_snapshot, save_snapshot
 
 class Simulator:
@@ -85,7 +86,7 @@ class Simulator:
         # do not join threads  let the API return quickly
         return applied
 
-    def create_group(self, name: str, member_ids: List[str]) -> Group:
+    def create_group(self, name: str, member_ids: List[str], layout: GroupLayout | None = None) -> Group:
         # generate a simple id like G-1 G-2 ...
         existing_ids = set(self.snap.groups.keys())
         n = 1
@@ -95,18 +96,19 @@ class Simulator:
 
         # filter to only valid panel ids
         valid_ids = [pid for pid in member_ids if pid in self.snap.panels]
+        normalized_layout = normalize_group_layout(valid_ids, layout)
 
-        group = Group(id=gid, name=name, member_ids=valid_ids)
+        group = Group(id=gid, name=name, member_ids=valid_ids, layout=normalized_layout)
         self.snap.groups[gid] = group
 
         save_snapshot(self.snap)
         return group
-
     def update_group(
         self,
         group_id: str,
         name: str | None,
         member_ids: List[str] | None,
+        layout: GroupLayout | None = None,
     ) -> Group:
         if group_id not in self.snap.groups:
             raise KeyError(group_id)
@@ -120,6 +122,9 @@ class Simulator:
             # normalize to only existing panels
             new_ids = [pid for pid in member_ids if pid in self.snap.panels]
             g.member_ids = list(new_ids)
+            g.layout = normalize_group_layout(g.member_ids, layout or g.layout)
+        elif layout is not None:
+            g.layout = normalize_group_layout(g.member_ids, layout)
 
         save_snapshot(self.snap)
         return g

--- a/svc/app/state.py
+++ b/svc/app/state.py
@@ -5,6 +5,7 @@ import time
 import sqlite3
 from contextlib import contextmanager
 from typing import Dict, List, Tuple, Any, Iterator, Optional, Callable
+from .group_layout import normalize_group_layout
 from .models import Panel, Group, Snapshot, AuditEntry
 from .config import PANELS_FILE, PANELS_CONFIG_FILE, PANELS_STATE_FILE, AUDIT_DB_FILE
 
@@ -143,13 +144,14 @@ def _migrate_from_legacy_panels_json() -> None:
                 if isinstance(group_data, dict):
                     conn.execute(
                         """
-                        INSERT INTO groups (id, name, member_ids)
-                        VALUES (?, ?, ?)
+                        INSERT INTO groups (id, name, member_ids, layout_json)
+                        VALUES (?, ?, ?, ?)
                         """,
                         (
                             group_id,
                             group_data.get("name", f"Group {group_id}"),
                             json.dumps(group_data.get("member_ids", [])),
+                            json.dumps(group_data.get("layout")) if group_data.get("layout") is not None else None,
                         ),
                     )
 
@@ -214,19 +216,25 @@ def load_groups() -> Dict[str, Group]:
     _ensure_groups_db()  # Only ensure table exists, no migration
 
     with _db_connection() as conn:
-        rows = conn.execute("SELECT id, name, member_ids FROM groups").fetchall()
+        rows = conn.execute("SELECT id, name, member_ids, layout_json FROM groups").fetchall()
         
         groups = {}
         for row in rows:
-            group_id, name, member_ids_json = row
+            group_id, name, member_ids_json, layout_json = row
             try:
                 member_ids = json.loads(member_ids_json) if member_ids_json else []
             except Exception:
                 member_ids = []
+            try:
+                layout_data = json.loads(layout_json) if layout_json else None
+                layout = normalize_group_layout(member_ids, layout_data) if layout_data else None
+            except Exception:
+                layout = None
             groups[group_id] = Group(
                 id=group_id,
                 name=name,
                 member_ids=member_ids,
+                layout=layout,
             )
         
         return groups
@@ -243,12 +251,18 @@ def save_groups(groups: Dict[str, Group]) -> None:
         
         # Insert all groups
         for group_id, group in groups.items():
+            layout = normalize_group_layout(group.member_ids, group.layout)
             conn.execute(
                 """
-                INSERT INTO groups (id, name, member_ids)
-                VALUES (?, ?, ?)
+                INSERT INTO groups (id, name, member_ids, layout_json)
+                VALUES (?, ?, ?, ?)
                 """,
-                (group.id, group.name, json.dumps(group.member_ids)),
+                (
+                    group.id,
+                    group.name,
+                    json.dumps(group.member_ids),
+                    json.dumps(layout.model_dump(exclude_none=True)) if layout is not None else None,
+                ),
             )
 
 
@@ -382,10 +396,14 @@ def _ensure_groups_db() -> None:
             CREATE TABLE IF NOT EXISTS groups (
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL,
-                member_ids TEXT NOT NULL
+                member_ids TEXT NOT NULL,
+                layout_json TEXT
             )
             """
         )
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(groups)").fetchall()}
+        if "layout_json" not in columns:
+            conn.execute("ALTER TABLE groups ADD COLUMN layout_json TEXT")
 
 
 def _ensure_routines_db() -> None:
@@ -763,13 +781,14 @@ def _migrate_groups_json_to_db() -> None:
             if isinstance(group_data, dict):
                 conn.execute(
                     """
-                    INSERT INTO groups (id, name, member_ids)
-                    VALUES (?, ?, ?)
+                    INSERT INTO groups (id, name, member_ids, layout_json)
+                    VALUES (?, ?, ?, ?)
                     """,
                     (
                         group_id,
                         group_data.get("name", f"Group {group_id}"),
                         json.dumps(group_data.get("member_ids", [])),
+                        json.dumps(group_data.get("layout")) if group_data.get("layout") is not None else None,
                     ),
                 )
         conn.commit()

--- a/svc/tests/test_groups_api.py
+++ b/svc/tests/test_groups_api.py
@@ -20,7 +20,17 @@ def test_group_crud_round_trip():
     try:
         create_response = client.post(
             "/groups",
-            json={"name": "CI Test Group", "member_ids": ["P01", "P02", "MISSING"]},
+            json={
+                "name": "CI Test Group",
+                "member_ids": ["P01", "P02", "MISSING"],
+                "layout": {
+                    "columns": 2,
+                    "items": [
+                        {"panel_id": "P01", "row": 1, "column": 2},
+                        {"panel_id": "P02", "row": 1, "column": 1},
+                    ],
+                },
+            },
         )
         assert create_response.status_code == 201
         created_group = create_response.json()
@@ -28,10 +38,24 @@ def test_group_crud_round_trip():
 
         assert created_group["name"] == "CI Test Group"
         assert created_group["member_ids"] == ["P01", "P02"]
+        assert created_group["layout"] == {
+            "columns": 2,
+            "items": [
+                {"panel_id": "P01", "row": 1, "column": 2},
+                {"panel_id": "P02", "row": 1, "column": 1},
+            ],
+        }
 
         update_response = client.patch(
             f"/groups/{group_id}",
-            json={"name": "Updated CI Test Group", "member_ids": ["SK1", "UNKNOWN"]},
+            json={
+                "name": "Updated CI Test Group",
+                "member_ids": ["SK1", "UNKNOWN"],
+                "layout": {
+                    "columns": 3,
+                    "items": [{"panel_id": "SK1", "row": 2, "column": 3}],
+                },
+            },
         )
         assert update_response.status_code == 200
         updated_group = update_response.json()
@@ -39,6 +63,10 @@ def test_group_crud_round_trip():
         assert updated_group["id"] == group_id
         assert updated_group["name"] == "Updated CI Test Group"
         assert updated_group["member_ids"] == ["SK1"]
+        assert updated_group["layout"] == {
+            "columns": 3,
+            "items": [{"panel_id": "SK1", "row": 2, "column": 3}],
+        }
 
         groups_response = client.get("/groups")
         assert groups_response.status_code == 200
@@ -55,3 +83,49 @@ def test_group_crud_round_trip():
     groups_after_delete = client.get("/groups")
     assert groups_after_delete.status_code == 200
     assert all(group["id"] != group_id for group in groups_after_delete.json())
+
+
+def test_group_layout_rows_and_dividers_round_trip():
+    sync_simulator_snapshot()
+    group_id = None
+
+    try:
+        create_response = client.post(
+            "/groups",
+            json={
+                "name": "CI Divider Layout Group",
+                "member_ids": ["P01", "P02"],
+                "layout": {
+                    "columns": 2,
+                    "rows": 3,
+                    "items": [
+                        {"panel_id": "P01", "row": 1, "column": 1},
+                        {"panel_id": "P02", "row": 1, "column": 2},
+                    ],
+                    "dividers": {
+                        "vertical": [{"row": 1, "column": 1}],
+                        "horizontal": [{"row": 1, "column": 1}, {"row": 1, "column": 2}],
+                    },
+                },
+            },
+        )
+        assert create_response.status_code == 201
+        created_group = create_response.json()
+        group_id = created_group["id"]
+
+        assert created_group["layout"] == {
+            "columns": 2,
+            "rows": 3,
+            "items": [
+                {"panel_id": "P01", "row": 1, "column": 1},
+                {"panel_id": "P02", "row": 1, "column": 2},
+            ],
+            "dividers": {
+                "vertical": [{"row": 1, "column": 1}],
+                "horizontal": [{"row": 1, "column": 1}, {"row": 1, "column": 2}],
+            },
+        }
+    finally:
+        if group_id is not None:
+            delete_response = client.delete(f"/groups/{group_id}")
+            assert delete_response.status_code == 200

--- a/svc/tests/test_real_mode.py
+++ b/svc/tests/test_real_mode.py
@@ -1,4 +1,5 @@
 from app.adapter import RealAdapter
+from app.models import Group
 from app.service import ControlService
 
 
@@ -33,6 +34,39 @@ def test_real_group_acceptance_with_unknown_members(monkeypatch):
     assert ok is True
     assert applied == []
     assert msg == "group updated"
+
+
+def test_service_list_groups_overlays_saved_layout(monkeypatch):
+    monkeypatch.setattr("app.service.MODE", "real")
+
+    class FakeRealAdapter:
+        def list_panels(self):
+            return []
+
+        def list_groups(self):
+            return [Group(id="halio-group", name="West", member_ids=["window-1"])]
+
+    monkeypatch.setattr("app.service.RealAdapter", FakeRealAdapter)
+    monkeypatch.setattr(
+        "app.service.load_groups",
+        lambda: {
+            "halio-group": Group(
+                id="halio-group",
+                name="West",
+                member_ids=["window-1"],
+                layout={"columns": 2, "items": [{"panel_id": "window-1", "row": 1, "column": 2}]},
+            )
+        },
+    )
+
+    service = ControlService()
+    groups = service.list_groups()
+
+    assert len(groups) == 1
+    assert groups[0].layout.model_dump() == {
+        "columns": 2,
+        "items": [{"panel_id": "window-1", "row": 1, "column": 2}],
+    }
 
 
 def test_list_groups_uses_group_details_for_member_ids(monkeypatch):
@@ -194,10 +228,21 @@ def test_create_group_uses_halio_post_shape(monkeypatch):
     monkeypatch.setattr("app.adapter.requests.get", fake_get)
 
     adapter = RealAdapter()
-    group = adapter.create_group("My Group", ["window-1", "window-2"])
+    group = adapter.create_group(
+        "My Group",
+        ["window-1", "window-2"],
+        {"columns": 2, "items": [{"panel_id": "window-2", "row": 1, "column": 1}]},
+    )
 
     assert captured_payloads == [
         {"group": {"name": "My Group", "windows": ["window-1", "window-2"]}}
     ]
     assert group.id == "group-9"
     assert group.member_ids == ["window-1", "window-2"]
+    assert group.layout.model_dump() == {
+        "columns": 2,
+        "items": [
+            {"panel_id": "window-1", "row": 1, "column": 2},
+            {"panel_id": "window-2", "row": 1, "column": 1},
+        ],
+    }

--- a/svc/tests/test_sqlite.py
+++ b/svc/tests/test_sqlite.py
@@ -394,7 +394,12 @@ class TestGroupOperations:
     def test_save_groups_creates_groups(self, temp_db):
         """save_groups should create group entries."""
         groups = {
-            "G-1": Group(id="G-1", name="Group 1", member_ids=["P01", "P02"]),
+            "G-1": Group(
+                id="G-1",
+                name="Group 1",
+                member_ids=["P01", "P02"],
+                layout={"columns": 2, "items": [{"panel_id": "P01", "row": 1, "column": 2}]},
+            ),
             "G-2": Group(id="G-2", name="Group 2", member_ids=["P03", "P04"]),
         }
         
@@ -405,6 +410,13 @@ class TestGroupOperations:
         assert len(loaded_groups) == 2
         assert loaded_groups["G-1"].name == "Group 1"
         assert loaded_groups["G-1"].member_ids == ["P01", "P02"]
+        assert loaded_groups["G-1"].layout.model_dump() == {
+            "columns": 2,
+            "items": [
+                {"panel_id": "P01", "row": 1, "column": 2},
+                {"panel_id": "P02", "row": 2, "column": 1},
+            ],
+        }
         assert loaded_groups["G-2"].name == "Group 2"
         assert loaded_groups["G-2"].member_ids == ["P03", "P04"]
     
@@ -547,6 +559,7 @@ class TestDatabaseInitialization:
             assert "id" in columns
             assert "name" in columns
             assert "member_ids" in columns
+            assert "layout_json" in columns
     
     def test_ensure_groups_db_is_idempotent(self, temp_db):
         """_ensure_groups_db should be safe to call multiple times."""
@@ -573,7 +586,15 @@ class TestMigration:
                 "P01": {"id": "P01", "name": "Panel 1"},
             },
             "groups": {
-                "G-1": {"id": "G-1", "name": "Group 1", "member_ids": ["P01", "P02"]},
+                "G-1": {
+                    "id": "G-1",
+                    "name": "Group 1",
+                    "member_ids": ["P01", "P02"],
+                    "layout": {
+                        "columns": 2,
+                        "items": [{"panel_id": "P01", "row": 1, "column": 2}],
+                    },
+                },
                 "G-2": {"id": "G-2", "name": "Group 2", "member_ids": ["P03"]},
             },
         }
@@ -592,6 +613,13 @@ class TestMigration:
         assert len(groups) == 2
         assert groups["G-1"].name == "Group 1"
         assert groups["G-1"].member_ids == ["P01", "P02"]
+        assert groups["G-1"].layout.model_dump() == {
+            "columns": 2,
+            "items": [
+                {"panel_id": "P01", "row": 1, "column": 2},
+                {"panel_id": "P02", "row": 2, "column": 1},
+            ],
+        }
         assert groups["G-2"].name == "Group 2"
         assert groups["G-2"].member_ids == ["P03"]
     

--- a/web/src/AppHMI.tsx
+++ b/web/src/AppHMI.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useRef, useState } from "react"
 import { api } from "./api";
-import { Panel, Group, AuditLogEntry } from "./types"
+import { Panel, Group, GroupLayout, AuditLogEntry } from "./types"
 import { mockApi } from "./mockData";
 import RoomGrid from "./components/RoomGrid";
-import RoomGridCompact from "./components/RoomGridCompact";
+import GroupLayoutView from "./components/GroupLayoutView";
 import SidePanel from "./components/SidePanel";
 import ActiveControllersBar from "./components/ActiveControllersBar";
 import { controlManager, type ControlSource } from "./utils/controlManager";
@@ -168,6 +168,7 @@ export default function AppHMI() {
     const { showToast } = useToast();
     const [groupId, setGroupId] = useState<string>("");
     const [groupLevel, setGroupLevel] = useState<number>(50);
+    const [controlViewMode, setControlViewMode] = useState<"flat" | "grouped">("flat");
     const [logsPanelOpen, setLogsPanelOpen] = useState<boolean>(false);
     const [auditLogs, setAuditLogs] = useState<AuditLogEntry[]>([]);
     const [logsLoading, setLogsLoading] = useState<boolean>(false);
@@ -195,10 +196,7 @@ export default function AppHMI() {
             setSensors(s);
             setLatestMetrics(m);
 
-            // set default group only once, without stomping user choice
-            if (g.length) {
-                setGroupId(prev => prev || g[0].id);
-            }
+            setGroupId(prev => (g.some(group => group.id === prev) ? prev : (g[0]?.id || "")));
 
             setHealth(`${h.status} • ${h.mode}`);
             setUsingMock(false);
@@ -211,9 +209,7 @@ export default function AppHMI() {
                 setSensors([]);
                 setLatestMetrics([]);
 
-                if (g.length) {
-                    setGroupId(prev => prev || g[0].id);
-                }
+                setGroupId(prev => (g.some(group => group.id === prev) ? prev : (g[0]?.id || "")));
 
                 setHealth(`${h.status} • ${h.mode} (mock)`);
                 setUsingMock(true);
@@ -352,13 +348,12 @@ export default function AppHMI() {
         }
     }
 
-    async function updateGroup(groupId: string, name: string, memberIds: string[]) {
+    async function updateGroup(groupId: string, name: string, memberIds: string[], layout: GroupLayout | null) {
         try {
             if (usingMock) {
-                // simple mock behavior  update in mockApi if you want
-                await mockApi.createGroup(name, memberIds);
+                await mockApi.updateGroup(groupId, name, memberIds, layout);
             } else {
-                await api.updateGroup(groupId, name, memberIds);
+                await api.updateGroup(groupId, name, memberIds, layout);
             }
             await refresh();
             showToast(`Group "${name}" updated`, "success");
@@ -377,8 +372,7 @@ export default function AppHMI() {
 
         try {
             if (usingMock) {
-                // remove from mockGroups and mockPanelState manually if you want
-                await api.deleteGroup(groupId); // or make a mockApi.deleteGroup
+                await mockApi.deleteGroup(groupId);
             } else {
                 await api.deleteGroup(groupId);
             }
@@ -392,12 +386,12 @@ export default function AppHMI() {
     }
 
 
-    async function createGroup(name: string, memberIds: string[]) {
+    async function createGroup(name: string, memberIds: string[], layout: GroupLayout | null) {
         try {
             if (usingMock) {
-                await mockApi.createGroup(name, memberIds);
+                await mockApi.createGroup(name, memberIds, layout);
             } else {
-                await api.createGroup(name, memberIds);
+                await api.createGroup(name, memberIds, layout);
             }
             await refresh();
             showToast(`Group "${name}" created successfully`, "success");
@@ -586,7 +580,7 @@ export default function AppHMI() {
                 </div>
             </header>
 
-            <main className={`hmi-main ${sidePanelOpen ? 'with-side-panel' : ''}`}>
+            <main className="hmi-main">
                 <div className="hmi-main-tabs">
                     <button
                         className={`hmi-main-tab ${mainTab === "control" ? "active" : ""}`}
@@ -618,9 +612,9 @@ export default function AppHMI() {
 
                                 <select
                                     id="hmi-group-select"
+                                    className="hmi-control-select hmi-group-select"
                                     value={groupId}
                                     onChange={e => setGroupId(e.target.value)}
-                                    style={{ padding: '4px 8px' }}
                                 >
                                     <option value="">Select a group</option>
                                     {groups.map(g => (
@@ -636,26 +630,52 @@ export default function AppHMI() {
                                     max={100}
                                     value={groupLevel}
                                     onChange={e => setGroupLevel(Math.max(0, Math.min(100, Number(e.target.value))))}
-                                    style={{ width: 80, padding: '4px 8px' }}
+                                    className="hmi-control-input hmi-group-level-input"
                                 />
 
                                 <button
-                                    className="hmi-manage-btn"
+                                    className="hmi-manage-btn hmi-control-action-btn"
                                     onClick={() => groupId && setGroup(groupId, groupLevel)}
                                     disabled={!groupId || busy === groupId}
                                     title="Set selected group level"
-                                    style={{ padding: '4px 10px' }}
                                 >
-                                    {busy === groupId ? 'Setting…' : 'Tint Group'}
+                                    {busy === groupId ? 'Setting...' : 'Tint Group'}
                                 </button>
 
 
                             </div>
                         </div>
 
-                        {/* room grids */}
-                        {sidePanelOpen ? (
-                            <RoomGridCompact panels={panels} transitioning={transitioning} panelControls={controlState.panelControls} />
+                        <div className="room-section control-view-card">
+                            <div className="room-header">
+                                <h2 className="room-title">Panel organization</h2>
+                            </div>
+                            <div className="control-view-toggle" role="tablist" aria-label="Panel organization view">
+                                <button
+                                    className={`control-view-toggle-btn ${controlViewMode === "flat" ? "active" : ""}`}
+                                    onClick={() => setControlViewMode("flat")}
+                                >
+                                    List View
+                                </button>
+                                <button
+                                    className={`control-view-toggle-btn ${controlViewMode === "grouped" ? "active" : ""}`}
+                                    onClick={() => setControlViewMode("grouped")}
+                                >
+                                    Group View
+                                </button>
+                            </div>
+                        </div>
+
+                        {controlViewMode === "grouped" ? (
+                            <GroupLayoutView
+                                panels={panels}
+                                groups={groupId ? groups.filter(group => group.id === groupId) : []}
+                                onSet={setPanel}
+                                busyId={busy}
+                                transitioning={transitioning}
+                                panelControls={controlState.panelControls}
+                                emptyMessage={groupId ? "The selected group has no windows to display." : "Select a group in Group control to display its 2D layout."}
+                            />
                         ) : (
                             <RoomGrid
                                 panels={panels}
@@ -732,10 +752,33 @@ export default function AppHMI() {
                         || availableGraphMetrics[0]
                         || "";
                     const sensorKindLabel = SENSOR_KIND_LABELS[sensor.kind] || sensor.kind;
+                    const graphMetricSelector = availableGraphMetrics.length > 1 ? (
+                        <div className="sensor-graph-controls-inline">
+                            <label className="hmi-status-label" htmlFor={`sensor-graph-metric-${sensor.id}`}>Graph metric</label>
+                            <select
+                                id={`sensor-graph-metric-${sensor.id}`}
+                                className="sensor-graph-select"
+                                value={selectedGraphMetric}
+                                onChange={(e) => {
+                                    const nextMetric = e.target.value;
+                                    setGraphMetricBySensor(prev => ({ ...prev, [sensor.id]: nextMetric }));
+                                }}
+                            >
+                                {availableGraphMetrics.map(metric => (
+                                    <option key={`${sensor.id}-graph-${metric}`} value={metric}>
+                                        {METRIC_LABELS[metric] || metric}
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+                    ) : null;
 
                     return (
-                        <React.Fragment key={sensor.id}>
-                            <div className="room-section" style={{ marginTop: 20 }}>
+                        <div
+                            key={sensor.id}
+                            className={`sensor-dashboard-row ${selectedGraphMetric ? "" : "metrics-only"}`}
+                        >
+                            <div className="room-section sensor-metrics-panel">
                                 <div className="room-header">
                                     <h2 className="room-title">{`${sensor.label || sensor.id} - Latest metrics`}</h2>
                                     <div className="room-stats">
@@ -744,16 +787,16 @@ export default function AppHMI() {
                                         <span style={{ marginLeft: 8 }}>{orderedMetricNames.length} metrics</span>
                                     </div>
                                 </div>
-                                <div style={{ padding: "12px 16px", display: "grid", gridTemplateColumns: "1fr auto", gap: 8 }}>
+                                <div className="sensor-metrics-grid">
                                     {orderedMetricNames.length === 0 && (
-                                        <div style={{ gridColumn: "1 / span 2", color: "#9ca3af" }}>
+                                        <div className="sensor-metrics-empty">
                                             Waiting for sensor data...
                                         </div>
                                     )}
                                     {orderedMetricNames.map(metric => (
                                         <React.Fragment key={`${sensor.id}-${metric}`}>
-                                            <div style={{ color: "#e5e7eb" }}>{METRIC_LABELS[metric] || metric}</div>
-                                            <div style={{ color: "#f9fafb", fontVariantNumeric: "tabular-nums" }}>
+                                            <div className="sensor-metric-name">{METRIC_LABELS[metric] || metric}</div>
+                                            <div className="sensor-metric-value">
                                                 {formatMetricValue(metric, metricMap.get(metric) as number)}
                                             </div>
                                         </React.Fragment>
@@ -761,42 +804,18 @@ export default function AppHMI() {
                                 </div>
                             </div>
 
-                            {selectedGraphMetric && availableGraphMetrics.length > 1 && (
-                                <>
-                                    <div className="sensor-graph-controls">
-                                        <label className="hmi-status-label">Graph metric</label>
-                                        <select
-                                            className="sensor-graph-select"
-                                            value={selectedGraphMetric}
-                                            onChange={(e) => {
-                                                const nextMetric = e.target.value;
-                                                setGraphMetricBySensor(prev => ({ ...prev, [sensor.id]: nextMetric }));
-                                            }}
-                                        >
-                                            {availableGraphMetrics.map(metric => (
-                                                <option key={`${sensor.id}-graph-${metric}`} value={metric}>
-                                                    {METRIC_LABELS[metric] || metric}
-                                                </option>
-                                            ))}
-                                        </select>
-                                    </div>
-                                    <LiveGraph
-                                        sensorId={sensor.id}
-                                        metric={selectedGraphMetric}
-                                        label={`${sensor.label || sensor.id} - ${METRIC_LABELS[selectedGraphMetric] || selectedGraphMetric}`}
-                                        color={sensorGraphColor(sensor.kind)}
-                                    />
-                                </>
-                            )}
-                            {selectedGraphMetric && availableGraphMetrics.length <= 1 && (
+                            {selectedGraphMetric && (
                                 <LiveGraph
                                     sensorId={sensor.id}
                                     metric={selectedGraphMetric}
                                     label={`${sensor.label || sensor.id} - ${METRIC_LABELS[selectedGraphMetric] || selectedGraphMetric}`}
                                     color={sensorGraphColor(sensor.kind)}
+                                    height={360}
+                                    toolbar={graphMetricSelector}
+                                    className="sensor-graph-panel"
                                 />
                             )}
-                        </React.Fragment>
+                        </div>
                     );
                 })}
 

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -50,6 +50,29 @@ describe("api", () => {
         });
     });
 
+    it("sends group layout metadata in group create requests", async () => {
+        fetchMock.mockResolvedValue(
+            jsonResponse({ id: "G-3", name: "West", member_ids: ["P01"], layout: { columns: 2, items: [] } }),
+        );
+
+        await api.createGroup("West", ["P01"], {
+            columns: 2,
+            items: [{ panel_id: "P01", row: 1, column: 2 }],
+        });
+
+        const [path, options] = fetchMock.mock.calls[0];
+        expect(path).toBe("/groups");
+        expect(options).toMatchObject({ method: "POST" });
+        expect(JSON.parse(String(options?.body))).toEqual({
+            name: "West",
+            member_ids: ["P01"],
+            layout: {
+                columns: 2,
+                items: [{ panel_id: "P01", row: 1, column: 2 }],
+            },
+        });
+    });
+
     it("surfaces HTTP status codes in thrown errors", async () => {
         fetchMock.mockResolvedValue(
             new Response("dwell time not met", {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,4 +1,4 @@
-import { Panel, Group, AuditLogEntry, SortField, SortDir } from "./types";
+import { Panel, Group, GroupLayout, AuditLogEntry, SortField, SortDir } from "./types";
 
 /** Empty default: same-origin when served behind Docker/nginx; set VITE_API_BASE for local Vite dev. */
 export const API_BASE = (import.meta.env.VITE_API_BASE || "").replace(/\/$/, "");
@@ -26,15 +26,15 @@ export const api = {
     health: () => http<{ status: string; mode: string }>("/health"),
     panels: () => http<Panel[]>("/panels"),
     groups: () => http<Group[]>("/groups"),
-    createGroup: (name: string, memberIds: string[]) =>
+    createGroup: (name: string, memberIds: string[], layout?: GroupLayout | null) =>
         http<Group>("/groups", {
             method: "POST",
-            body: JSON.stringify({ name, member_ids: memberIds })
+            body: JSON.stringify({ name, member_ids: memberIds, layout: layout ?? null })
         }),
-    updateGroup: (groupId: string, name: string, memberIds: string[]) =>
+    updateGroup: (groupId: string, name: string, memberIds: string[], layout?: GroupLayout | null) =>
         http<Group>(`/groups/${groupId}`, {
             method: "PATCH",
-            body: JSON.stringify({ name, member_ids: memberIds })
+            body: JSON.stringify({ name, member_ids: memberIds, layout: layout ?? null })
         }),
     deleteGroup: (groupId: string) =>
         http<unknown>(`/groups/${groupId}`, {

--- a/web/src/components/GroupLayoutEditor.tsx
+++ b/web/src/components/GroupLayoutEditor.tsx
@@ -1,0 +1,393 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { GroupLayout, GroupLayoutDivider, GroupLayoutDividers, Panel } from "../types";
+import {
+    DEFAULT_GROUP_LAYOUT_COLUMNS,
+    MAX_GROUP_LAYOUT_COLUMNS,
+    layoutItemMap,
+    normalizeGroupLayout,
+} from "../utils/groupLayout";
+import { sortPanelsByNumber } from "../utils/panelSort";
+
+type Props = {
+    panels: Panel[];
+    selectedPanelIds: Set<string>;
+    onTogglePanel: (panelId: string) => void;
+    layout: GroupLayout | null;
+    onLayoutChange: (layout: GroupLayout | null) => void;
+};
+
+type DividerKind = keyof GroupLayoutDividers;
+
+function clampColumns(value: number): number {
+    if (!Number.isFinite(value)) return DEFAULT_GROUP_LAYOUT_COLUMNS;
+    if (value < 1) return 1;
+    if (value > MAX_GROUP_LAYOUT_COLUMNS) return MAX_GROUP_LAYOUT_COLUMNS;
+    return Math.floor(value);
+}
+
+function dividerKey(divider: GroupLayoutDivider): string {
+    return `${divider.row}:${divider.column}`;
+}
+
+function getDividers(layout: GroupLayout): GroupLayoutDividers {
+    return {
+        vertical: layout.dividers?.vertical ?? [],
+        horizontal: layout.dividers?.horizontal ?? [],
+    };
+}
+
+function hasAnyDividers(dividers: GroupLayoutDividers): boolean {
+    return dividers.vertical.length > 0 || dividers.horizontal.length > 0;
+}
+
+export default function GroupLayoutEditor({
+    panels,
+    selectedPanelIds,
+    onTogglePanel,
+    layout,
+    onLayoutChange,
+}: Props) {
+    const sortedPanels = sortPanelsByNumber(panels);
+    const selectedIds = sortedPanels.filter(panel => selectedPanelIds.has(panel.id)).map(panel => panel.id);
+    const panelById = new Map(sortedPanels.map(panel => [panel.id, panel]));
+    const effectiveLayout = normalizeGroupLayout(selectedIds, layout);
+    const itemMap = layoutItemMap(effectiveLayout);
+    const [columnInputValue, setColumnInputValue] = useState(String(effectiveLayout?.columns ?? DEFAULT_GROUP_LAYOUT_COLUMNS));
+    const [draggingPanelId, setDraggingPanelId] = useState<string | null>(null);
+    const lastValidColumnsRef = useRef(effectiveLayout?.columns ?? DEFAULT_GROUP_LAYOUT_COLUMNS);
+
+    useEffect(() => {
+        const nextColumns = effectiveLayout?.columns ?? DEFAULT_GROUP_LAYOUT_COLUMNS;
+        lastValidColumnsRef.current = nextColumns;
+        setColumnInputValue(String(nextColumns));
+    }, [effectiveLayout?.columns]);
+
+    const updateLayout = (nextLayout: GroupLayout | null) => {
+        onLayoutChange(normalizeGroupLayout(selectedIds, nextLayout));
+    };
+
+    const commitColumns = (rawValue: string) => {
+        const fallback = lastValidColumnsRef.current || DEFAULT_GROUP_LAYOUT_COLUMNS;
+        const nextColumns = rawValue.trim() === "" ? fallback : clampColumns(Number(rawValue));
+        lastValidColumnsRef.current = nextColumns;
+        setColumnInputValue(String(nextColumns));
+
+        if (effectiveLayout) {
+            updateLayout({ ...effectiveLayout, columns: nextColumns });
+        }
+    };
+
+    const handleColumnInputChange = (rawValue: string) => {
+        setColumnInputValue(rawValue);
+        if (rawValue.trim() === "") return;
+
+        const nextColumns = clampColumns(Number(rawValue));
+        lastValidColumnsRef.current = nextColumns;
+        setColumnInputValue(String(nextColumns));
+        if (effectiveLayout) {
+            updateLayout({ ...effectiveLayout, columns: nextColumns });
+        }
+    };
+
+    const nudgeColumns = (delta: number) => {
+        const current = columnInputValue.trim() === ""
+            ? (lastValidColumnsRef.current || DEFAULT_GROUP_LAYOUT_COLUMNS)
+            : Number(columnInputValue);
+        commitColumns(String(clampColumns(current + delta)));
+    };
+
+    const movePanelToCell = (panelId: string, row: number, column: number) => {
+        if (!effectiveLayout) return;
+        const currentItem = itemMap.get(panelId);
+        if (!currentItem) return;
+
+        const targetItem = effectiveLayout.items.find(item => item.row === row && item.column === column);
+        const items = effectiveLayout.items.map(item => {
+            if (item.panel_id === panelId) {
+                return { ...item, row, column };
+            }
+
+            if (targetItem && item.panel_id === targetItem.panel_id) {
+                return { ...item, row: currentItem.row, column: currentItem.column };
+            }
+
+            return item;
+        });
+
+        updateLayout({ ...effectiveLayout, items });
+    };
+
+    const movePanelByKeyboard = (panelId: string, rowDelta: number, columnDelta: number) => {
+        if (!effectiveLayout) return;
+        const item = itemMap.get(panelId);
+        if (!item) return;
+        const nextRow = Math.max(1, item.row + rowDelta);
+        const nextColumn = Math.max(1, Math.min(effectiveLayout.columns, item.column + columnDelta));
+        movePanelToCell(panelId, nextRow, nextColumn);
+    };
+
+    const addRow = () => {
+        if (!effectiveLayout) return;
+        updateLayout({ ...effectiveLayout, rows: rowCount + 1 });
+    };
+
+    const updateDividers = (
+        kind: DividerKind,
+        segments: GroupLayoutDivider[],
+        mode: "line" | "single",
+    ) => {
+        if (!effectiveLayout) return;
+
+        const current = getDividers(effectiveLayout);
+        const currentList = current[kind];
+        const segmentKeys = new Set(segments.map(dividerKey));
+        const currentKeys = new Set(currentList.map(dividerKey));
+        const shouldRemove = mode === "single"
+            ? segments.every(segment => currentKeys.has(dividerKey(segment)))
+            : segments.every(segment => currentKeys.has(dividerKey(segment)));
+
+        const nextList = shouldRemove
+            ? currentList.filter(divider => !segmentKeys.has(dividerKey(divider)))
+            : [
+                ...currentList,
+                ...segments.filter(segment => !currentKeys.has(dividerKey(segment))),
+            ];
+        const nextDividers = { ...current, [kind]: nextList };
+
+        updateLayout({
+            ...effectiveLayout,
+            dividers: hasAnyDividers(nextDividers) ? nextDividers : undefined,
+        });
+    };
+
+    const columns = effectiveLayout?.columns ?? DEFAULT_GROUP_LAYOUT_COLUMNS;
+    const occupiedRowCount = effectiveLayout
+        ? Math.max(
+            1,
+            Math.ceil(selectedIds.length / columns),
+            ...effectiveLayout.items.map(item => item.row),
+            effectiveLayout.rows ?? 1,
+        )
+        : 0;
+    const rowCount = occupiedRowCount;
+    const gridTemplateColumns = Array.from({ length: Math.max(1, columns * 2 - 1) }, (_, index) =>
+        index % 2 === 0 ? "minmax(0, 1fr)" : "20px",
+    ).join(" ");
+    const gridTemplateRows = Array.from({ length: Math.max(1, rowCount * 2 - 1) }, (_, index) =>
+        index % 2 === 0 ? "minmax(82px, auto)" : "20px",
+    ).join(" ");
+    const verticalDividerKeys = new Set(effectiveLayout?.dividers?.vertical.map(dividerKey) ?? []);
+    const horizontalDividerKeys = new Set(effectiveLayout?.dividers?.horizontal.map(dividerKey) ?? []);
+
+    return (
+        <>
+            <div className="form-group">
+                <label>Select Windows ({selectedPanelIds.size} selected)</label>
+                <div className="panel-selector">
+                    {sortedPanels.map(panel => (
+                        <label key={panel.id} className="panel-checkbox">
+                            <input
+                                type="checkbox"
+                                checked={selectedPanelIds.has(panel.id)}
+                                onChange={() => onTogglePanel(panel.id)}
+                            />
+                            <span>{panel.name}</span>
+                            <span className="panel-id">{panel.id}</span>
+                        </label>
+                    ))}
+                </div>
+            </div>
+
+            {effectiveLayout && (
+                <div className="group-layout-editor">
+                    <div className="form-group">
+                        <label>Layout Columns</label>
+                        <input
+                            className="group-layout-column-input"
+                            type="number"
+                            min={1}
+                            max={MAX_GROUP_LAYOUT_COLUMNS}
+                            step={1}
+                            inputMode="numeric"
+                            value={columnInputValue}
+                            onChange={event => handleColumnInputChange(event.target.value)}
+                            onBlur={event => commitColumns(event.target.value)}
+                            onKeyDown={event => {
+                                if (event.key === "ArrowUp") {
+                                    event.preventDefault();
+                                    nudgeColumns(1);
+                                }
+                                if (event.key === "ArrowDown") {
+                                    event.preventDefault();
+                                    nudgeColumns(-1);
+                                }
+                                if (event.key === "Enter") {
+                                    commitColumns(event.currentTarget.value);
+                                }
+                            }}
+                        />
+                        <div className="group-layout-hint">
+                            Drag panels to rearrange them. Right-click a panel to remove it. Left-click a divider strip to toggle its full row or column; right-click toggles one strip.
+                        </div>
+                    </div>
+
+                    <div className="group-layout-preview-wrapper">
+                        <div className="group-layout-preview-label">2D Preview</div>
+                        <div
+                            className="group-layout-preview-grid"
+                            style={{
+                                gridTemplateColumns,
+                                gridTemplateRows,
+                            }}
+                        >
+                            {Array.from({ length: rowCount }).flatMap((_, rowIndex) => {
+                                const row = rowIndex + 1;
+                                const cells = Array.from({ length: columns }).map((__, columnIndex) => {
+                                    const column = columnIndex + 1;
+                                    const item = effectiveLayout.items.find(entry => entry.row === row && entry.column === column);
+                                    const panel = item ? panelById.get(item.panel_id) : null;
+
+                                    return (
+                                        <div
+                                            key={`cell-${row}-${column}`}
+                                            className={`group-layout-preview-cell ${draggingPanelId ? "drag-active" : ""}`}
+                                            style={{ gridColumn: column * 2 - 1, gridRow: row * 2 - 1 }}
+                                            onDragOver={event => event.preventDefault()}
+                                            onDrop={event => {
+                                                event.preventDefault();
+                                                const panelId = event.dataTransfer.getData("text/plain") || draggingPanelId;
+                                                if (panelId) movePanelToCell(panelId, row, column);
+                                                setDraggingPanelId(null);
+                                            }}
+                                        >
+                                            {panel && item && (
+                                                <div
+                                                    className="group-layout-preview-tile"
+                                                    draggable
+                                                    tabIndex={0}
+                                                    title="Right-click to remove from group, drag to move, or use arrow keys while focused"
+                                                    onClick={event => {
+                                                        event.stopPropagation();
+                                                    }}
+                                                    onContextMenu={event => {
+                                                        event.preventDefault();
+                                                        event.stopPropagation();
+                                                        onTogglePanel(panel.id);
+                                                    }}
+                                                    onDragStart={event => {
+                                                        event.dataTransfer.setData("text/plain", panel.id);
+                                                        event.dataTransfer.effectAllowed = "move";
+                                                        setDraggingPanelId(panel.id);
+                                                    }}
+                                                    onDragEnd={() => setDraggingPanelId(null)}
+                                                    onKeyDown={event => {
+                                                        if (event.key === "ArrowUp") {
+                                                            event.preventDefault();
+                                                            movePanelByKeyboard(panel.id, -1, 0);
+                                                        }
+                                                        if (event.key === "ArrowDown") {
+                                                            event.preventDefault();
+                                                            movePanelByKeyboard(panel.id, 1, 0);
+                                                        }
+                                                        if (event.key === "ArrowLeft") {
+                                                            event.preventDefault();
+                                                            movePanelByKeyboard(panel.id, 0, -1);
+                                                        }
+                                                        if (event.key === "ArrowRight") {
+                                                            event.preventDefault();
+                                                            movePanelByKeyboard(panel.id, 0, 1);
+                                                        }
+                                                    }}
+                                                >
+                                                    <div className="group-layout-preview-name">{panel.name}</div>
+                                                    <div className="group-layout-preview-id">{panel.id}</div>
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                });
+
+                                const verticalDividers = Array.from({ length: Math.max(0, columns - 1) }).map((__, columnIndex) => {
+                                    const column = columnIndex + 1;
+                                    const divider = { row, column };
+                                    const isActive = verticalDividerKeys.has(dividerKey(divider));
+
+                                    return (
+                                        <button
+                                            key={`vertical-divider-${row}-${column}`}
+                                            type="button"
+                                            className={`group-layout-divider-strip vertical ${isActive ? "active" : ""}`}
+                                            style={{ gridColumn: column * 2, gridRow: row * 2 - 1 }}
+                                            aria-pressed={isActive}
+                                            title="Left-click toggles this column divider for every row. Right-click toggles this strip only."
+                                            onClick={event => {
+                                                event.preventDefault();
+                                                updateDividers(
+                                                    "vertical",
+                                                    Array.from({ length: rowCount }).map((___, lineRowIndex) => ({
+                                                        row: lineRowIndex + 1,
+                                                        column,
+                                                    })),
+                                                    "line",
+                                                );
+                                            }}
+                                            onContextMenu={event => {
+                                                event.preventDefault();
+                                                updateDividers("vertical", [divider], "single");
+                                            }}
+                                        />
+                                    );
+                                });
+
+                                if (row >= rowCount) return [...cells, ...verticalDividers];
+
+                                const horizontalDividers = Array.from({ length: columns }).map((__, columnIndex) => {
+                                    const row = rowIndex + 1;
+                                    const column = columnIndex + 1;
+                                    const divider = { row, column };
+                                    const isActive = horizontalDividerKeys.has(dividerKey(divider));
+
+                                    return (
+                                        <button
+                                            key={`horizontal-divider-${row}-${column}`}
+                                            type="button"
+                                            className={`group-layout-divider-strip horizontal ${isActive ? "active" : ""}`}
+                                            style={{ gridColumn: column * 2 - 1, gridRow: row * 2 }}
+                                            aria-pressed={isActive}
+                                            title="Left-click toggles this row divider for every column. Right-click toggles this strip only."
+                                            onClick={event => {
+                                                event.preventDefault();
+                                                updateDividers(
+                                                    "horizontal",
+                                                    Array.from({ length: columns }).map((___, lineColumnIndex) => ({
+                                                        row,
+                                                        column: lineColumnIndex + 1,
+                                                    })),
+                                                    "line",
+                                                );
+                                            }}
+                                            onContextMenu={event => {
+                                                event.preventDefault();
+                                                updateDividers("horizontal", [divider], "single");
+                                            }}
+                                        />
+                                    );
+                                });
+
+                                return [...cells, ...verticalDividers, ...horizontalDividers];
+                            })}
+                        </div>
+                        <button
+                            type="button"
+                            className="group-layout-add-row-btn"
+                            onClick={addRow}
+                        >
+                            Add Row
+                        </button>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}

--- a/web/src/components/GroupLayoutView.tsx
+++ b/web/src/components/GroupLayoutView.tsx
@@ -1,0 +1,186 @@
+import type { Group, Panel } from "../types";
+import type { ControlSource } from "../utils/controlManager";
+import { layoutItemMap, normalizeGroupLayout } from "../utils/groupLayout";
+
+import PanelTile from "./PanelTile";
+
+type Props = {
+    panels: Panel[];
+    groups: Group[];
+    onSet: (panelId: string, level: number) => Promise<void>;
+    busyId?: string | null;
+    transitioning?: Set<string>;
+    panelControls?: Map<string, ControlSource>;
+    emptyMessage?: string;
+};
+
+function dividerKey(row: number, column: number): string {
+    return `${row}:${column}`;
+}
+
+function gridTemplateTrackList(
+    count: number,
+    boundaryIndexes: Set<number>,
+    dividerGap: string,
+    baseGap: string,
+    itemTrack: string,
+): string {
+    const tracks: string[] = [];
+    for (let index = 1; index <= count; index += 1) {
+        tracks.push(itemTrack);
+        if (index < count) {
+            tracks.push(boundaryIndexes.has(index) ? dividerGap : baseGap);
+        }
+    }
+    return tracks.join(" ");
+}
+
+export default function GroupLayoutView({
+    panels,
+    groups,
+    onSet,
+    busyId,
+    transitioning = new Set(),
+    panelControls = new Map(),
+    emptyMessage = "No groups are available yet. Create a group to use the 2D layout view.",
+}: Props) {
+    const panelsById = new Map(panels.map(panel => [panel.id, panel]));
+    const visibleGroups = [...groups]
+        .filter(group => group.member_ids.length > 0)
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    return (
+        <div className="room-grid-container">
+            <div className="group-layout-sections">
+                {visibleGroups.map(group => {
+                    const layout = normalizeGroupLayout(group.member_ids, group.layout);
+                    const itemMap = layoutItemMap(layout);
+                    const groupPanels = group.member_ids
+                        .map(panelId => panelsById.get(panelId))
+                        .filter((panel): panel is Panel => Boolean(panel));
+
+                    if (!groupPanels.length || !layout) {
+                        return null;
+                    }
+
+                    const verticalDividers = layout.dividers?.vertical ?? [];
+                    const horizontalDividers = layout.dividers?.horizontal ?? [];
+                    const rowCount = Math.max(
+                        1,
+                        layout.rows ?? 1,
+                        ...layout.items.map(item => item.row),
+                        ...verticalDividers.map(divider => divider.row),
+                        ...horizontalDividers.map(divider => divider.row + 1),
+                    );
+                    const hasDividers = Boolean(verticalDividers.length || horizontalDividers.length);
+                    const verticalDividerKeys = new Set(verticalDividers.map(divider => dividerKey(divider.row, divider.column)));
+                    const horizontalDividerKeys = new Set(horizontalDividers.map(divider => dividerKey(divider.row, divider.column)));
+                    const dividerColumnBoundaries = new Set(verticalDividers.map(divider => divider.column));
+                    const dividerRowBoundaries = new Set(horizontalDividers.map(divider => divider.row));
+                    const gridTemplateColumns = hasDividers
+                        ? gridTemplateTrackList(layout.columns, dividerColumnBoundaries, "50px", "16px", "minmax(0, 1fr)")
+                        : `repeat(${layout.columns}, minmax(0, 1fr))`;
+                    const gridTemplateRows = hasDividers
+                        ? gridTemplateTrackList(rowCount, dividerRowBoundaries, "50px", "16px", "auto")
+                        : undefined;
+                    const dividerIntersections = Array.from({ length: Math.max(0, rowCount - 1) }).flatMap((_, rowIndex) => {
+                        const row = rowIndex + 1;
+                        return Array.from({ length: Math.max(0, layout.columns - 1) }).map((__, columnIndex) => {
+                            const column = columnIndex + 1;
+                            const verticalAbove = verticalDividerKeys.has(dividerKey(row, column));
+                            const verticalBelow = verticalDividerKeys.has(dividerKey(row + 1, column));
+                            const horizontalLeft = horizontalDividerKeys.has(dividerKey(row, column));
+                            const horizontalRight = horizontalDividerKeys.has(dividerKey(row, column + 1));
+                            const touchesVertical = verticalAbove || verticalBelow;
+                            const touchesHorizontal = horizontalLeft || horizontalRight;
+
+                            if (touchesVertical && touchesHorizontal) {
+                                return { row, column, orientation: "horizontal" as const };
+                            }
+                            if (verticalAbove && verticalBelow) {
+                                return { row, column, orientation: "vertical" as const };
+                            }
+                            if (horizontalLeft && horizontalRight) {
+                                return { row, column, orientation: "horizontal" as const };
+                            }
+                            return null;
+                        });
+                    }).filter((intersection): intersection is { row: number; column: number; orientation: "horizontal" | "vertical" } => Boolean(intersection));
+
+                    return (
+                        <div key={group.id} className="room-section group-layout-section">
+                            <div className="room-header">
+                                <div>
+                                    <h2 className="room-title">{group.name}</h2>
+                                    <div className="group-layout-subtitle">{group.id}</div>
+                                </div>
+                                <div className="room-stats">
+                                    <span>{groupPanels.length} windows</span>
+                                    <span>{layout.columns} columns</span>
+                                </div>
+                            </div>
+
+                            <div
+                                className={`group-layout-grid ${hasDividers ? "with-dividers" : ""}`}
+                                style={{ gridTemplateColumns, gridTemplateRows }}
+                            >
+                                {groupPanels.map(panel => {
+                                    const item = itemMap.get(panel.id);
+                                    if (!item) return null;
+
+                                    return (
+                                        <div
+                                            key={`${group.id}-${panel.id}`}
+                                            className="group-layout-cell"
+                                            style={{
+                                                gridColumn: hasDividers ? item.column * 2 - 1 : item.column,
+                                                gridRow: hasDividers ? item.row * 2 - 1 : item.row,
+                                            }}
+                                        >
+                                            <PanelTile
+                                                panel={panel}
+                                                onSet={onSet}
+                                                busyId={busyId}
+                                                isTransitioning={transitioning.has(panel.id)}
+                                                controlSource={panelControls.get(panel.id)}
+                                            />
+                                        </div>
+                                    );
+                                })}
+                                {hasDividers && verticalDividers.map(divider => (
+                                    <div
+                                        key={`vertical-${dividerKey(divider.row, divider.column)}`}
+                                        className="group-layout-view-divider vertical"
+                                        style={{ gridColumn: divider.column * 2, gridRow: divider.row * 2 - 1 }}
+                                    />
+                                ))}
+                                {hasDividers && horizontalDividers.map(divider => (
+                                    <div
+                                        key={`horizontal-${dividerKey(divider.row, divider.column)}`}
+                                        className="group-layout-view-divider horizontal"
+                                        style={{ gridColumn: divider.column * 2 - 1, gridRow: divider.row * 2 }}
+                                    />
+                                ))}
+                                {hasDividers && dividerIntersections.map(intersection => (
+                                    <div
+                                        key={`intersection-${intersection.orientation}-${dividerKey(intersection.row, intersection.column)}`}
+                                        className={`group-layout-view-divider intersection ${intersection.orientation}`}
+                                        style={{ gridColumn: intersection.column * 2, gridRow: intersection.row * 2 }}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    );
+                })}
+
+                {!visibleGroups.length && (
+                    <div className="room-section">
+                        <div className="group-layout-empty">
+                            {emptyMessage}
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/web/src/components/LiveGraph.tsx
+++ b/web/src/components/LiveGraph.tsx
@@ -8,9 +8,19 @@ interface LiveGraphProps {
     color?: string;
     label?: string;
     height?: number;
+    toolbar?: React.ReactNode;
+    className?: string;
 }
 
-export default function LiveGraph({ sensorId, metric, color = "#8884d8", label, height = 300 }: LiveGraphProps) {
+export default function LiveGraph({
+    sensorId,
+    metric,
+    color = "#8884d8",
+    label,
+    height = 300,
+    toolbar,
+    className = "",
+}: LiveGraphProps) {
     const [data, setData] = useState<SensorReadingResponse[]>([]);
     const [loading, setLoading] = useState(true);
 
@@ -35,25 +45,30 @@ export default function LiveGraph({ sensorId, metric, color = "#8884d8", label, 
         return () => clearInterval(interval);
     }, [sensorId, metric]);
 
-    if (loading && !data.length) {
-        return <div style={{ height, display: "flex", alignItems: "center", justifyContent: "center", color: "#666" }}>Loading graph...</div>;
-    }
-
-    if (!data.length) {
-        return <div style={{ height, display: "flex", alignItems: "center", justifyContent: "center", color: "#666" }}>No data available</div>;
-    }
-
     const formatTime = (ts: number) => {
         const d = new Date(ts * 1000);
         return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     };
 
-    return (
-        <div className="room-section" style={{ marginTop: 20 }}>
-            <div className="room-header">
-                <h2 className="room-title">{label || `${sensorId} - ${metric}`}</h2>
-            </div>
-            <div style={{ height, padding: "10px 20px 20px 0" }}>
+    const renderGraphBody = () => {
+        if (loading && !data.length) {
+            return (
+                <div className="live-graph-empty" style={{ height }}>
+                    Loading graph...
+                </div>
+            );
+        }
+
+        if (!data.length) {
+            return (
+                <div className="live-graph-empty" style={{ height }}>
+                    No data available
+                </div>
+            );
+        }
+
+        return (
+            <div className="live-graph-chart" style={{ height }}>
                 <ResponsiveContainer width="100%" height="100%">
                     <AreaChart data={data}>
                         <defs>
@@ -76,7 +91,7 @@ export default function LiveGraph({ sensorId, metric, color = "#8884d8", label, 
                         />
                         <Tooltip
                             contentStyle={{ backgroundColor: '#222', border: '1px solid #444', borderRadius: 4, color: '#fff' }}
-                            labelFormatter={(label) => new Date(label * 1000).toLocaleString()}
+                            labelFormatter={(tooltipLabel) => new Date(Number(tooltipLabel) * 1000).toLocaleString()}
                             formatter={(value: number | undefined) => [value != null ? value.toFixed(1) : "N/A", metric]}
                         />
                         <Area
@@ -90,6 +105,16 @@ export default function LiveGraph({ sensorId, metric, color = "#8884d8", label, 
                     </AreaChart>
                 </ResponsiveContainer>
             </div>
+        );
+    };
+
+    return (
+        <div className={`room-section live-graph-section ${className}`}>
+            <div className="room-header live-graph-header">
+                <h2 className="room-title">{label || `${sensorId} - ${metric}`}</h2>
+                {toolbar && <div className="live-graph-toolbar">{toolbar}</div>}
+            </div>
+            {renderGraphBody()}
         </div>
     );
 }

--- a/web/src/components/PanelTile.tsx
+++ b/web/src/components/PanelTile.tsx
@@ -1,0 +1,239 @@
+import React from "react";
+
+import type { Panel } from "../types";
+import type { ControlSource } from "../utils/controlManager";
+
+type Props = {
+    panel: Panel;
+    onSet: (id: string, level: number) => Promise<void>;
+    busyId?: string | null;
+    isTransitioning?: boolean;
+    controlSource?: ControlSource | null;
+    className?: string;
+};
+
+function formatLastUpdated(timestamp: number, currentTime?: number): string {
+    if (!timestamp || timestamp === 0) {
+        return "Never";
+    }
+
+    const now = currentTime || (Date.now() / 1000);
+    const diff = now - timestamp;
+
+    if (diff < 5) return "Just now";
+    if (diff < 60) {
+        const seconds = Math.floor(diff);
+        return `${seconds} second${seconds !== 1 ? "s" : ""} ago`;
+    }
+    if (diff < 3600) {
+        const minutes = Math.floor(diff / 60);
+        return `${minutes} minute${minutes !== 1 ? "s" : ""} ago`;
+    }
+    if (diff < 86400) {
+        const hours = Math.floor(diff / 3600);
+        return `${hours} hour${hours !== 1 ? "s" : ""} ago`;
+    }
+
+    const days = Math.floor(diff / 86400);
+    return `${days} day${days !== 1 ? "s" : ""} ago`;
+}
+
+function getTintColor(level: number) {
+    if (level === 0) return "#e8f3ff";
+    if (level < 25) return "#9ec5ff";
+    if (level < 50) return "#6ba3ff";
+    if (level < 75) return "#3d7fd6";
+    return "#1e4a8c";
+}
+
+function getTextColor(level: number) {
+    return level < 50 ? "#1e293b" : "#ffffff";
+}
+
+export default function PanelTile({
+    panel,
+    onSet,
+    busyId,
+    isTransitioning,
+    controlSource,
+    className,
+}: Props) {
+    const [localLevel, setLocalLevel] = React.useState(panel.level);
+    const [currentTime, setCurrentTime] = React.useState(Date.now() / 1000);
+    const [isInteracting, setIsInteracting] = React.useState(false);
+    const interactionTimeoutRef = React.useRef<number | null>(null);
+    const isSkylight = panel.name.toUpperCase().includes("SK") || panel.id.startsWith("SK");
+
+    React.useEffect(() => {
+        if (!isInteracting) {
+            setLocalLevel(panel.level);
+        }
+    }, [panel.level, isInteracting]);
+
+    React.useEffect(() => {
+        if (busyId !== panel.id && localLevel !== panel.level && !isInteracting) {
+            setLocalLevel(panel.level);
+        }
+    }, [busyId, panel.id, panel.level, localLevel, isInteracting]);
+
+    React.useEffect(() => {
+        const interval = window.setInterval(() => {
+            setCurrentTime(Date.now() / 1000);
+        }, 10000);
+        return () => window.clearInterval(interval);
+    }, []);
+
+    React.useEffect(() => () => {
+        if (interactionTimeoutRef.current) {
+            window.clearTimeout(interactionTimeoutRef.current);
+            interactionTimeoutRef.current = null;
+        }
+    }, []);
+
+    const isBusy = busyId === panel.id;
+
+    const badge = (() => {
+        if (!controlSource || controlSource.type === "manual") return null;
+        switch (controlSource.type) {
+            case "group":
+                return { label: "Group", className: "control-badge-group", icon: "G" };
+            case "routine":
+                return { label: "Routine", className: "control-badge-routine", icon: "R" };
+        }
+    })();
+
+    const controlBorderClass = !controlSource
+        ? "panel-controlled-manual"
+        : `panel-controlled-${controlSource.type}`;
+
+    const readSliderValue = () => {
+        const element = document.getElementById(`range-${panel.id}`) as HTMLInputElement | null;
+        if (!element) return panel.level;
+        const value = Number(element.value);
+        return Number.isNaN(value) ? panel.level : Math.max(0, Math.min(100, value));
+    };
+
+    const startInteraction = () => {
+        if (interactionTimeoutRef.current) {
+            window.clearTimeout(interactionTimeoutRef.current);
+            interactionTimeoutRef.current = null;
+        }
+        setIsInteracting(true);
+    };
+
+    const endInteractionDebounced = () => {
+        if (interactionTimeoutRef.current) {
+            window.clearTimeout(interactionTimeoutRef.current);
+        }
+        interactionTimeoutRef.current = window.setTimeout(() => {
+            interactionTimeoutRef.current = null;
+            setIsInteracting(false);
+        }, 600);
+    };
+
+    return (
+        <div
+            className={`panel-tile ${isSkylight ? "panel-tile-skylight" : ""} ${isBusy ? "panel-tile-busy" : ""} ${isTransitioning ? "panel-tile-transitioning" : ""} ${controlBorderClass} ${className || ""}`}
+        >
+            <div className="panel-tile-header">
+                <div className="panel-tile-name">{panel.name}</div>
+                <div className="panel-tile-header-right">
+                    {badge && (
+                        <div className={`control-badge ${badge.className}`} title={`Controlled by: ${badge.label}`}>
+                            <span className="control-badge-icon">{badge.icon}</span>
+                            <span className="control-badge-label">{badge.label}</span>
+                        </div>
+                    )}
+                    <div className="panel-tile-id">{panel.id}</div>
+                </div>
+            </div>
+
+            <div className="panel-tile-status">
+                <div className="panel-tile-level-display" style={{ backgroundColor: getTintColor(localLevel) }}>
+                    <span className="panel-tile-level-value" style={{ color: getTextColor(localLevel) }}>
+                        {localLevel}%
+                    </span>
+                    {isTransitioning && (
+                        <div className="panel-tile-transition-indicator">
+                            <div className="panel-tile-transition-spinner" />
+                            <span className="panel-tile-transition-label">Transitioning...</span>
+                        </div>
+                    )}
+                </div>
+                <div className="panel-tile-timestamp">
+                    <span className="panel-tile-timestamp-label">Updated:</span>
+                    <span className="panel-tile-timestamp-value">{formatLastUpdated(panel.last_change_ts, currentTime)}</span>
+                </div>
+            </div>
+
+            <div className="panel-tile-controls">
+                <div className="panel-tile-slider-wrapper">
+                    <input
+                        type="range"
+                        min={0}
+                        max={100}
+                        defaultValue={panel.level}
+                        id={`range-${panel.id}`}
+                        disabled={isBusy}
+                        onPointerDown={startInteraction}
+                        onMouseDown={startInteraction}
+                        onTouchStart={startInteraction}
+                        onPointerUp={endInteractionDebounced}
+                        onMouseUp={endInteractionDebounced}
+                        onTouchEnd={endInteractionDebounced}
+                        onPointerCancel={() => {
+                            if (interactionTimeoutRef.current) {
+                                window.clearTimeout(interactionTimeoutRef.current);
+                                interactionTimeoutRef.current = null;
+                            }
+                            setIsInteracting(false);
+                        }}
+                        onBlur={() => {
+                            if (interactionTimeoutRef.current) {
+                                window.clearTimeout(interactionTimeoutRef.current);
+                                interactionTimeoutRef.current = null;
+                            }
+                            setIsInteracting(false);
+                        }}
+                        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+                            setLocalLevel(Number(event.currentTarget.value));
+                        }}
+                        className="panel-tile-slider"
+                    />
+                </div>
+
+                <div className="panel-tile-quick-controls">
+                    {[0, 25, 50, 75, 100].map(value => (
+                        <button
+                            key={value}
+                            className="panel-tile-quick-btn"
+                            disabled={isBusy}
+                            onClick={() => {
+                                const element = document.getElementById(`range-${panel.id}`) as HTMLInputElement | null;
+                                if (element) element.value = String(value);
+                                setLocalLevel(value);
+                            }}
+                        >
+                            {value}
+                        </button>
+                    ))}
+                </div>
+
+                <button
+                    className="panel-tile-apply-btn"
+                    disabled={isBusy || readSliderValue() === panel.level}
+                    onClick={async () => {
+                        const value = readSliderValue();
+                        try {
+                            await onSet(panel.id, value);
+                        } catch {
+                            setLocalLevel(panel.level);
+                        }
+                    }}
+                >
+                    {isBusy ? "..." : readSliderValue() === panel.level ? "OK" : "Apply"}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/web/src/components/RoomGrid.tsx
+++ b/web/src/components/RoomGrid.tsx
@@ -1,6 +1,8 @@
-import React, { useState } from "react";
 import type { Panel } from "../types";
 import type { ControlSource } from "../utils/controlManager";
+import { sortPanelsByNumber } from "../utils/panelSort";
+
+import PanelTile from "./PanelTile";
 
 type Props = {
     panels: Panel[];
@@ -10,254 +12,14 @@ type Props = {
     panelControls?: Map<string, ControlSource>;
 };
 
-// Format timestamp as relative time (e.g., "2 minutes ago", "Just now")
-function formatLastUpdated(timestamp: number, currentTime?: number): string {
-    if (!timestamp || timestamp === 0) {
-        return "Never";
-    }
-
-    const now = currentTime || (Date.now() / 1000); // Use provided currentTime or get current
-    const diff = now - timestamp;
-
-    if (diff < 5) {
-        return "Just now";
-    } else if (diff < 60) {
-        const seconds = Math.floor(diff);
-        return `${seconds} second${seconds !== 1 ? 's' : ''} ago`;
-    } else if (diff < 3600) {
-        const minutes = Math.floor(diff / 60);
-        return `${minutes} minute${minutes !== 1 ? 's' : ''} ago`;
-    } else if (diff < 86400) {
-        const hours = Math.floor(diff / 3600);
-        return `${hours} hour${hours !== 1 ? 's' : ''} ago`;
-    } else {
-        const days = Math.floor(diff / 86400);
-        return `${days} day${days !== 1 ? 's' : ''} ago`;
-    }
-}
-
-function PanelTile({
-    panel,
+export default function RoomGrid({
+    panels,
     onSet,
     busyId,
-    isTransitioning,
-    controlSource,
-    className
-}: {
-    panel: Panel
-    onSet: (id: string, level: number) => Promise<void>
-    busyId?: string | null
-    isTransitioning?: boolean
-    controlSource?: ControlSource | null
-    className?: string
-}) {
-    const [localLevel, setLocalLevel] = React.useState(panel.level)
-    const [currentTime, setCurrentTime] = React.useState(Date.now() / 1000)
-    const [isInteracting, setIsInteracting] = React.useState(false)
-    const interactionTimeoutRef = React.useRef<number | null>(null)
-    const isSkylight = panel.name.toUpperCase().includes('SK') || panel.id.startsWith('SK')
-
-    // sync localLevel when panel prop updates, but only when the user is not interacting
-    React.useEffect(() => {
-        if (!isInteracting) {
-            setLocalLevel(panel.level)
-        }
-    }, [panel.level, isInteracting])
-
-    // When operation completes (busyId changes from panel.id to null),
-    // verify localLevel matches actual panel.level and reset if needed
-    React.useEffect(() => {
-        if (busyId !== panel.id && localLevel !== panel.level && !isInteracting) {
-            setLocalLevel(panel.level)
-        }
-    }, [busyId, panel.id, panel.level, localLevel, isInteracting])
-
-    // Update timestamp display every 10 seconds
-    React.useEffect(() => {
-        const interval = setInterval(() => {
-            setCurrentTime(Date.now() / 1000)
-        }, 10000)
-        return () => clearInterval(interval)
-    }, [])
-
-    // cleanup interaction timeout on unmount
-    React.useEffect(() => {
-        return () => {
-            if (interactionTimeoutRef.current) {
-                window.clearTimeout(interactionTimeoutRef.current)
-                interactionTimeoutRef.current = null
-            }
-        }
-    }, [])
-
-    const getTintColor = (level: number) => {
-        if (level === 0) return '#e8f3ff'
-        if (level < 25) return '#9ec5ff'
-        if (level < 50) return '#6ba3ff'
-        if (level < 75) return '#3d7fd6'
-        return '#1e4a8c'
-    }
-
-    const getTextColor = (level: number) => {
-        return level < 50 ? '#1e293b' : '#ffffff'
-    }
-
-    const isBusy = busyId === panel.id
-
-    const getControlBadge = () => {
-        if (!controlSource || controlSource.type === 'manual') return null
-        switch (controlSource.type) {
-            case 'group':
-                return { label: 'Group', class: 'control-badge-group', icon: '▣' }
-            case 'routine':
-                return { label: 'Routine', class: 'control-badge-routine', icon: '⚙' }
-        }
-    }
-
-    const badge = getControlBadge()
-
-    const getControlBorderClass = () => {
-        if (!controlSource) return 'panel-controlled-manual'
-        return `panel-controlled-${controlSource.type}`
-    }
-
-    // helper to read the current value from the DOM slider
-    const readSliderValue = () => {
-        const el = document.getElementById(`range-${panel.id}`) as HTMLInputElement | null
-        if (!el) return panel.level
-        const v = Number(el.value)
-        return Number.isNaN(v) ? panel.level : Math.max(0, Math.min(100, v))
-    }
-
-    // pointer handlers to mark the user as interacting
-    const startInteraction = () => {
-        if (interactionTimeoutRef.current) {
-            window.clearTimeout(interactionTimeoutRef.current)
-            interactionTimeoutRef.current = null
-        }
-        setIsInteracting(true)
-    }
-
-    const endInteractionDebounced = () => {
-        if (interactionTimeoutRef.current) {
-            window.clearTimeout(interactionTimeoutRef.current)
-        }
-        // small delay after pointer up so quick flicks don't cause immediate re-sync
-        interactionTimeoutRef.current = window.setTimeout(() => {
-            interactionTimeoutRef.current = null
-            setIsInteracting(false)
-        }, 600)
-    }
-
-    return (
-        <div
-            className={`panel-tile ${isSkylight ? 'panel-tile-skylight' : ''} ${isBusy ? 'panel-tile-busy' : ''} ${isTransitioning ? 'panel-tile-transitioning' : ''} ${getControlBorderClass()} ${className || ''}`}
-        >
-            <div className="panel-tile-header">
-                <div className="panel-tile-name">{panel.name}</div>
-                    <div className="panel-tile-header-right">
-                    {badge && (
-                        <div className={`control-badge ${badge.class}`} title={`Controlled by: ${badge.label}`}>
-                            <span className="control-badge-icon">{badge.icon}</span>
-                            <span className="control-badge-label">{badge.label}</span>
-                        </div>
-                    )}
-                    <div className="panel-tile-id">{panel.id}</div>
-                </div>
-            </div>
-
-            <div className="panel-tile-status">
-                <div className="panel-tile-level-display" style={{ backgroundColor: getTintColor(localLevel) }}>
-                    <span className="panel-tile-level-value" style={{ color: getTextColor(localLevel) }}>{localLevel}%</span>
-                    {isTransitioning && (
-                        <div className="panel-tile-transition-indicator">
-                            <div className="panel-tile-transition-spinner" />
-                            <span className="panel-tile-transition-label">Transitioning...</span>
-                        </div>
-                    )}
-                </div>
-                <div className="panel-tile-timestamp">
-                    <span className="panel-tile-timestamp-label">Updated:</span>
-                    <span className="panel-tile-timestamp-value">{formatLastUpdated(panel.last_change_ts, currentTime)}</span>
-                </div>
-            </div>
-
-            <div className="panel-tile-controls">
-                <div className="panel-tile-slider-wrapper">
-                    <input
-                        type="range"
-                        min={0}
-                        max={100}
-                        defaultValue={panel.level}
-                        id={`range-${panel.id}`}
-                        disabled={isBusy}
-                        onPointerDown={startInteraction}
-                        onMouseDown={startInteraction}
-                        onTouchStart={startInteraction}
-                        onPointerUp={endInteractionDebounced}
-                        onMouseUp={endInteractionDebounced}
-                        onTouchEnd={endInteractionDebounced}
-                        onPointerCancel={() => {
-                            if (interactionTimeoutRef.current) {
-                                window.clearTimeout(interactionTimeoutRef.current)
-                                interactionTimeoutRef.current = null
-                            }
-                            setIsInteracting(false)
-                        }}
-                        onBlur={() => {
-                            if (interactionTimeoutRef.current) {
-                                window.clearTimeout(interactionTimeoutRef.current)
-                                interactionTimeoutRef.current = null
-                            }
-                            setIsInteracting(false)
-                        }}
-                        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                            const val = Number(e.currentTarget.value)
-                            setLocalLevel(val)
-                        }}
-                        className="panel-tile-slider"
-                    />
-                </div>
-
-                <div className="panel-tile-quick-controls">
-                    {[0, 25, 50, 75, 100].map(v => (
-                        <button
-                            key={v}
-                            className="panel-tile-quick-btn"
-                            disabled={isBusy}
-                            onClick={async () => {
-                                const el = document.getElementById(`range-${panel.id}`) as HTMLInputElement | null
-                                if (el) el.value = String(v)
-                                setLocalLevel(v)
-                            }}
-                        >
-                            {v}
-                        </button>
-                    ))}
-                </div>
-
-                <button
-                    className="panel-tile-apply-btn"
-                    disabled={isBusy || readSliderValue() === panel.level}
-                    onClick={async () => {
-                        const val = readSliderValue()
-                        try {
-                            await onSet(panel.id, val)
-                        } catch (e) {
-                            setLocalLevel(panel.level)
-                        }
-                    }}
-                >
-                    {isBusy ? '...' : readSliderValue() === panel.level ? '✓' : 'Apply'}
-                </button>
-            </div>
-        </div>
-    )
-}
-
-
-export default function RoomGrid({ panels, onSet, busyId, transitioning = new Set(), panelControls = new Map() }: Props) {
-    const sortedPanels = [...panels].sort((a, b) => a.name.localeCompare(b.name));
+    transitioning = new Set(),
+    panelControls = new Map(),
+}: Props) {
+    const sortedPanels = sortPanelsByNumber(panels);
 
     return (
         <div className="room-grid-container">
@@ -277,7 +39,11 @@ export default function RoomGrid({ panels, onSet, busyId, transitioning = new Se
                             busyId={busyId}
                             isTransitioning={transitioning.has(panel.id)}
                             controlSource={panelControls.get(panel.id)}
-                            className={(panel.name.toUpperCase().includes('SK') || panel.id.startsWith('SK')) ? "panel-tile-skylight-featured" : undefined}
+                            className={
+                                panel.name.toUpperCase().includes("SK") || panel.id.startsWith("SK")
+                                    ? "panel-tile-skylight-featured"
+                                    : undefined
+                            }
                         />
                     ))}
                 </div>
@@ -285,4 +51,3 @@ export default function RoomGrid({ panels, onSet, busyId, transitioning = new Se
         </div>
     );
 }
-

--- a/web/src/components/SidePanel.tsx
+++ b/web/src/components/SidePanel.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
-import type { Panel, Group } from "../types";
+import React, { useRef, useState } from "react";
+
+import type { Group, GroupLayout, Panel } from "../types";
+import { normalizeGroupLayout } from "../utils/groupLayout";
 import { useToast } from "../utils/toast";
+import GroupLayoutEditor from "./GroupLayoutEditor";
 import RoutineCodeEditor from "./RoutineCodeEditor";
 
 type Props = {
@@ -9,11 +12,31 @@ type Props = {
     onClose: () => void;
     panels: Panel[];
     groups: Group[];
-    onGroupCreate: (name: string, memberIds: string[]) => Promise<void>;
-    onGroupUpdate?: (groupId: string, name: string, memberIds: string[]) => Promise<void>;
+    onGroupCreate: (name: string, memberIds: string[], layout: GroupLayout | null) => Promise<void>;
+    onGroupUpdate?: (groupId: string, name: string, memberIds: string[], layout: GroupLayout | null) => Promise<void>;
     onGroupDelete?: (groupId: string) => Promise<void>;
     targetRoutineId?: string | null;
 };
+
+const MIN_SIDE_PANEL_WIDTH = 420;
+const MAX_SIDE_PANEL_WIDTH = 900;
+
+function togglePanelSelection(
+    previous: Set<string>,
+    panelId: string,
+): Set<string> {
+    const next = new Set(previous);
+    if (next.has(panelId)) next.delete(panelId);
+    else next.add(panelId);
+    return next;
+}
+
+function clampSidePanelWidth(width: number): number {
+    const viewportLimit = typeof window === "undefined"
+        ? MAX_SIDE_PANEL_WIDTH
+        : Math.max(MIN_SIDE_PANEL_WIDTH, window.innerWidth - 48);
+    return Math.max(MIN_SIDE_PANEL_WIDTH, Math.min(width, MAX_SIDE_PANEL_WIDTH, viewportLimit));
+}
 
 export default function SidePanel({
     isOpen,
@@ -24,30 +47,28 @@ export default function SidePanel({
     onGroupCreate,
     onGroupUpdate,
     onGroupDelete,
-    targetRoutineId
+    targetRoutineId,
 }: Props) {
-    const sortedPanels = [...panels].sort((a, b) => a.name.localeCompare(b.name));
     const sortedGroups = [...groups].sort((a, b) => a.name.localeCompare(b.name));
     const { showToast } = useToast();
+    const [panelWidth, setPanelWidth] = useState(520);
+    const resizeRef = useRef<{ startX: number; startWidth: number } | null>(null);
 
-    // group creation state
     const [newGroupName, setNewGroupName] = useState("");
     const [selectedPanelIds, setSelectedPanelIds] = useState<Set<string>>(new Set());
+    const [newGroupLayout, setNewGroupLayout] = useState<GroupLayout | null>(null);
     const [isCreatingGroup, setIsCreatingGroup] = useState(false);
 
-    // group edit state
     const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
     const [editGroupName, setEditGroupName] = useState("");
     const [editMemberIds, setEditMemberIds] = useState<Set<string>>(new Set());
+    const [editGroupLayout, setEditGroupLayout] = useState<GroupLayout | null>(null);
     const [isSavingGroup, setIsSavingGroup] = useState(false);
 
-    const handlePanelToggle = (panelId: string) => {
-        setSelectedPanelIds(prev => {
-            const next = new Set(prev);
-            if (next.has(panelId)) next.delete(panelId);
-            else next.add(panelId);
-            return next;
-        });
+    const handleCreatePanelToggle = (panelId: string) => {
+        const next = togglePanelSelection(selectedPanelIds, panelId);
+        setSelectedPanelIds(next);
+        setNewGroupLayout(normalizeGroupLayout(Array.from(next), newGroupLayout));
     };
 
     const handleCreateGroup = async () => {
@@ -58,9 +79,11 @@ export default function SidePanel({
 
         setIsCreatingGroup(true);
         try {
-            await onGroupCreate(newGroupName.trim(), Array.from(selectedPanelIds));
+            const memberIds = Array.from(selectedPanelIds);
+            await onGroupCreate(newGroupName.trim(), memberIds, normalizeGroupLayout(memberIds, newGroupLayout));
             setNewGroupName("");
             setSelectedPanelIds(new Set());
+            setNewGroupLayout(null);
         } catch {
             // AppHMI shows error toast
         } finally {
@@ -72,15 +95,13 @@ export default function SidePanel({
         setEditingGroupId(group.id);
         setEditGroupName(group.name);
         setEditMemberIds(new Set(group.member_ids));
+        setEditGroupLayout(normalizeGroupLayout(group.member_ids, group.layout));
     };
 
     const handleEditPanelToggle = (panelId: string) => {
-        setEditMemberIds(prev => {
-            const next = new Set(prev);
-            if (next.has(panelId)) next.delete(panelId);
-            else next.add(panelId);
-            return next;
-        });
+        const next = togglePanelSelection(editMemberIds, panelId);
+        setEditMemberIds(next);
+        setEditGroupLayout(normalizeGroupLayout(Array.from(next), editGroupLayout));
     };
 
     const handleSaveGroupChanges = async () => {
@@ -91,17 +112,19 @@ export default function SidePanel({
 
         setIsSavingGroup(true);
         try {
+            const memberIds = Array.from(editMemberIds);
             await onGroupUpdate(
                 editingGroupId,
                 editGroupName.trim(),
-                Array.from(editMemberIds)
+                memberIds,
+                normalizeGroupLayout(memberIds, editGroupLayout),
             );
-
             setEditingGroupId(null);
             setEditGroupName("");
             setEditMemberIds(new Set());
+            setEditGroupLayout(null);
         } catch {
-            // toast already shown in AppHMI
+            // AppHMI shows error toast
         } finally {
             setIsSavingGroup(false);
         }
@@ -120,9 +143,10 @@ export default function SidePanel({
                 setEditingGroupId(null);
                 setEditGroupName("");
                 setEditMemberIds(new Set());
+                setEditGroupLayout(null);
             }
         } catch {
-            // error toast already from AppHMI
+            // AppHMI shows error toast
         }
     };
 
@@ -130,6 +154,30 @@ export default function SidePanel({
         setEditingGroupId(null);
         setEditGroupName("");
         setEditMemberIds(new Set());
+        setEditGroupLayout(null);
+    };
+
+    const startResizing = (event: React.MouseEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        resizeRef.current = { startX: event.clientX, startWidth: panelWidth };
+        document.body.classList.add("side-panel-resizing");
+
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+            const state = resizeRef.current;
+            if (!state) return;
+            setPanelWidth(clampSidePanelWidth(state.startWidth + state.startX - moveEvent.clientX));
+        };
+
+        const stopResizing = () => {
+            resizeRef.current = null;
+            document.body.classList.remove("side-panel-resizing");
+            document.removeEventListener("mousemove", handleMouseMove);
+            document.removeEventListener("mouseup", stopResizing);
+        };
+
+        document.addEventListener("mousemove", handleMouseMove);
+        document.addEventListener("mouseup", stopResizing);
     };
 
     if (!isOpen) return null;
@@ -137,11 +185,22 @@ export default function SidePanel({
     return (
         <>
             <div className="side-panel-overlay" onClick={onClose} />
-            <div className="side-panel" onClick={(e) => e.stopPropagation()}>
+            <div
+                className="side-panel"
+                style={{ width: `min(${panelWidth}px, calc(100vw - 24px))` }}
+                onClick={event => event.stopPropagation()}
+            >
+                <div
+                    className="side-panel-resize-handle"
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label="Resize side panel"
+                    onMouseDown={startResizing}
+                />
                 <div className="side-panel-header">
                     <h2>{mode === "groups" ? "Groups" : "Routines"}</h2>
                     <button className="side-panel-close" onClick={onClose} aria-label="Close panel">
-                        ✕
+                        X
                     </button>
                 </div>
 
@@ -154,36 +213,23 @@ export default function SidePanel({
                                 <input
                                     type="text"
                                     value={newGroupName}
-                                    onChange={e => setNewGroupName(e.target.value)}
+                                    onChange={event => setNewGroupName(event.target.value)}
                                     placeholder="e.g., West Windows"
                                 />
                             </div>
 
-                            <div className="form-group">
-                                <label>Select Windows ({selectedPanelIds.size} selected)</label>
-                                <div className="panel-selector">
-                                    {sortedPanels.map(panel => (
-                                        <label key={panel.id} className="panel-checkbox">
-                                            <input
-                                                type="checkbox"
-                                                checked={selectedPanelIds.has(panel.id)}
-                                                onChange={() => handlePanelToggle(panel.id)}
-                                            />
-                                            <span>{panel.name}</span>
-                                            <span className="panel-id">{panel.id}</span>
-                                        </label>
-                                    ))}
-                                </div>
-                            </div>
+                            <GroupLayoutEditor
+                                panels={panels}
+                                selectedPanelIds={selectedPanelIds}
+                                onTogglePanel={handleCreatePanelToggle}
+                                layout={newGroupLayout}
+                                onLayoutChange={setNewGroupLayout}
+                            />
 
                             <button
                                 className="side-panel-action-btn"
                                 onClick={handleCreateGroup}
-                                disabled={
-                                    isCreatingGroup ||
-                                    !newGroupName.trim() ||
-                                    selectedPanelIds.size === 0
-                                }
+                                disabled={isCreatingGroup || !newGroupName.trim() || selectedPanelIds.size === 0}
                             >
                                 {isCreatingGroup ? "Creating..." : "Create Group"}
                             </button>
@@ -194,6 +240,7 @@ export default function SidePanel({
                             <div className="groups-list">
                                 {sortedGroups.map(group => {
                                     const isEditing = editingGroupId === group.id;
+
                                     return (
                                         <div key={group.id} className="group-item">
                                             <div className="group-item-header">
@@ -201,53 +248,38 @@ export default function SidePanel({
                                                     <input
                                                         type="text"
                                                         value={editGroupName}
-                                                        onChange={e => setEditGroupName(e.target.value)}
+                                                        onChange={event => setEditGroupName(event.target.value)}
                                                         placeholder="Group name"
                                                     />
                                                 ) : (
-                                                    <strong>{group.name}</strong>
+                                                    <div className="group-item-title">
+                                                        <strong>{group.name}</strong>
+                                                        <span className="group-item-layout-status">
+                                                            {group.layout ? "Custom 2D layout" : "Auto layout"}
+                                                        </span>
+                                                    </div>
                                                 )}
                                                 <span className="group-item-id">{group.id}</span>
                                             </div>
 
                                             {isEditing ? (
                                                 <>
-                                                    <div className="form-group">
-                                                        <label>Edit members</label>
-                                                        <div className="panel-selector">
-                                                            {sortedPanels.map(panel => (
-                                                                <label key={panel.id} className="panel-checkbox">
-                                                                    <input
-                                                                        type="checkbox"
-                                                                        checked={editMemberIds.has(panel.id)}
-                                                                        onChange={() =>
-                                                                            handleEditPanelToggle(panel.id)
-                                                                        }
-                                                                    />
-                                                                    <span>{panel.name}</span>
-                                                                    <span className="panel-id">
-                                                                        {panel.id}
-                                                                    </span>
-                                                                </label>
-                                                            ))}
-                                                        </div>
-                                                    </div>
-                                                    <div style={{ display: "flex", gap: 8 }}>
+                                                    <GroupLayoutEditor
+                                                        panels={panels}
+                                                        selectedPanelIds={editMemberIds}
+                                                        onTogglePanel={handleEditPanelToggle}
+                                                        layout={editGroupLayout}
+                                                        onLayoutChange={setEditGroupLayout}
+                                                    />
+                                                    <div className="group-item-actions">
                                                         <button
                                                             className="side-panel-action-btn"
                                                             onClick={handleSaveGroupChanges}
-                                                            disabled={
-                                                                !editingGroupId ||
-                                                                !editGroupName.trim() ||
-                                                                isSavingGroup
-                                                            }
+                                                            disabled={!editGroupName.trim() || isSavingGroup}
                                                         >
                                                             {isSavingGroup ? "Saving..." : "Save Changes"}
                                                         </button>
-                                                        <button
-                                                            className="side-panel-secondary-btn"
-                                                            onClick={cancelEditing}
-                                                        >
+                                                        <button className="side-panel-secondary-btn" onClick={cancelEditing}>
                                                             Cancel
                                                         </button>
                                                     </div>
@@ -255,16 +287,9 @@ export default function SidePanel({
                                             ) : (
                                                 <>
                                                     <div className="group-item-members">
-                                                        {group.member_ids.length} window
-                                                        {group.member_ids.length !== 1 ? "s" : ""}
+                                                        {group.member_ids.length} window{group.member_ids.length !== 1 ? "s" : ""}
                                                     </div>
-                                                    <div
-                                                        style={{
-                                                            display: "flex",
-                                                            gap: 8,
-                                                            marginTop: 8
-                                                        }}
-                                                    >
+                                                    <div className="group-item-actions">
                                                         <button
                                                             className="side-panel-secondary-btn"
                                                             onClick={() => startEditingGroup(group)}

--- a/web/src/mockData.ts
+++ b/web/src/mockData.ts
@@ -1,4 +1,5 @@
-import {Panel, Group} from "./types"
+import { Panel, Group, GroupLayout } from "./types"
+import { normalizeGroupLayout } from "./utils/groupLayout";
 
 
 // Mock panels data - 18 wall panels (P01-P18) and 2 skylights (SK1, SK2) = 20 total
@@ -34,12 +35,17 @@ export const mockGroups: Group[] = [
     {
         id: "G-facade",
         name: "Facade",
-        member_ids: Array.from({ length: 18 }, (_, i) => `P${String(i + 1).padStart(2, '0')}`)
+        member_ids: Array.from({ length: 18 }, (_, i) => `P${String(i + 1).padStart(2, '0')}`),
+        layout: normalizeGroupLayout(
+            Array.from({ length: 18 }, (_, i) => `P${String(i + 1).padStart(2, '0')}`),
+            { columns: 6, items: [] },
+        ),
     },
     {
         id: "G-skylights",
         name: "Skylights",
-        member_ids: ["SK1", "SK2"]
+        member_ids: ["SK1", "SK2"],
+        layout: normalizeGroupLayout(["SK1", "SK2"], { columns: 2, items: [] }),
     }
 ];
 
@@ -60,7 +66,7 @@ export const mockApi = {
         return [...mockGroups];
     },
     
-    async createGroup(name: string, memberIds: string[]): Promise<Group> {
+    async createGroup(name: string, memberIds: string[], layout?: GroupLayout | null): Promise<Group> {
         await delay(300);
         // Generate unique group ID
         const existingIds = new Set(mockGroups.map(g => g.id));
@@ -79,7 +85,8 @@ export const mockApi = {
         const newGroup: Group = {
             id: groupId,
             name,
-            member_ids: validPanelIds
+            member_ids: validPanelIds,
+            layout: normalizeGroupLayout(validPanelIds, layout ?? null),
         };
         mockGroups.push(newGroup);
         return newGroup;
@@ -160,7 +167,7 @@ export const mockApi = {
     },
 
 
-    async updateGroup(id: string, name?: string, memberIds?: string[]): Promise<Group> {
+    async updateGroup(id: string, name?: string, memberIds?: string[], layout?: GroupLayout | null): Promise<Group> {
         await delay(300);
         const g = mockGroups.find(gr => gr.id === id);
         if (!g) throw new Error("group not found");
@@ -170,6 +177,7 @@ export const mockApi = {
             const valid = memberIds.filter(pid => mockPanelState.some(p => p.id === pid));
             g.member_ids = [...valid];
         }
+        g.layout = normalizeGroupLayout(g.member_ids, layout ?? g.layout ?? null);
         return { ...g };
     },
 

--- a/web/src/styles-hmi.css
+++ b/web/src/styles-hmi.css
@@ -379,6 +379,28 @@ body {
     transform: translateY(0);
 }
 
+.hmi-control-select {
+    min-width: 260px;
+    height: 40px;
+}
+
+.hmi-group-select {
+    width: min(360px, 100%);
+}
+
+.hmi-control-input {
+    height: 40px;
+}
+
+.hmi-group-level-input {
+    width: 112px;
+}
+
+.hmi-control-action-btn {
+    min-width: 132px;
+    padding: 10px 18px;
+}
+
 .hmi-clear-all-btn {
     padding: 8px 16px;
     background: linear-gradient(135deg, var(--hmi-warning) 0%, #f97316 100%);
@@ -899,6 +921,42 @@ body {
     overflow: hidden;
 }
 
+.side-panel-resize-handle {
+    position: absolute;
+    top: 0;
+    left: -6px;
+    width: 12px;
+    height: 100%;
+    cursor: ew-resize;
+    z-index: 2;
+    background: transparent;
+}
+
+.side-panel-resize-handle::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 5px;
+    width: 2px;
+    height: 64px;
+    transform: translateY(-50%);
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.45);
+    opacity: 0;
+    transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.side-panel-resize-handle:hover::after,
+.side-panel-resizing .side-panel-resize-handle::after {
+    opacity: 1;
+    background: var(--hmi-accent);
+}
+
+.side-panel-resizing {
+    cursor: ew-resize;
+    user-select: none;
+}
+
 @keyframes slide-in {
     from {
         transform: translateX(100%);
@@ -1254,6 +1312,17 @@ select option[disabled] {
     font-size: 14px;
 }
 
+.group-item-title {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.group-item-layout-status {
+    font-size: 11px;
+    color: var(--hmi-text-dim);
+}
+
 .group-item-id {
     font-size: 11px;
     color: var(--hmi-text-muted);
@@ -1265,6 +1334,214 @@ select option[disabled] {
 .group-item-members {
     font-size: 12px;
     color: var(--hmi-text-muted);
+}
+
+.group-item-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.group-layout-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.group-layout-hint {
+    margin-top: 6px;
+    font-size: 11px;
+    color: var(--hmi-text-dim);
+}
+
+.group-layout-column-input {
+    max-width: 112px;
+    min-width: 112px;
+}
+
+.group-layout-position-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.group-layout-position-item {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 92px 92px;
+    gap: 10px;
+    align-items: end;
+    padding: 10px;
+    border: 1px solid var(--hmi-border);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.02);
+}
+
+.group-layout-position-item label {
+    margin-bottom: 0;
+}
+
+.group-layout-position-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.group-layout-position-panel span {
+    font-size: 11px;
+    color: var(--hmi-text-muted);
+}
+
+.group-layout-preview-wrapper {
+    border: 1px solid var(--hmi-border);
+    border-radius: 8px;
+    padding: 12px;
+    background: var(--hmi-bg-alt);
+}
+
+.group-layout-preview-label {
+    margin-bottom: 10px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--hmi-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.group-layout-preview-grid {
+    display: grid;
+    gap: 0;
+}
+
+.group-layout-preview-cell {
+    min-height: 82px;
+    border: 1px dashed var(--hmi-border);
+    border-radius: 8px;
+    padding: 4px;
+    background: rgba(255, 255, 255, 0.015);
+    transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.group-layout-preview-cell.drag-active {
+    border-color: rgba(14, 165, 233, 0.55);
+    background: rgba(14, 165, 233, 0.06);
+}
+
+.group-layout-preview-tile {
+    min-height: 72px;
+    height: 100%;
+    border: 1px solid var(--hmi-border);
+    border-radius: 8px;
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.16), rgba(14, 165, 233, 0.08));
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    cursor: grab;
+    user-select: none;
+}
+
+.group-layout-preview-tile:active {
+    cursor: grabbing;
+}
+
+.group-layout-preview-tile:focus {
+    outline: 2px solid var(--hmi-accent);
+    outline-offset: 2px;
+}
+
+.group-layout-preview-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--hmi-text);
+}
+
+.group-layout-preview-id {
+    font-size: 11px;
+    color: var(--hmi-text-muted);
+}
+
+.group-layout-divider-strip {
+    display: block;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    position: relative;
+    border-radius: 999px;
+    background: transparent;
+    box-shadow: none;
+    cursor: pointer;
+}
+
+.group-layout-divider-strip::before {
+    content: "";
+    position: absolute;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.2);
+    transition: background 0.15s ease, box-shadow 0.15s ease;
+}
+
+.group-layout-divider-strip:hover::before {
+    background: rgba(14, 165, 233, 0.35);
+    box-shadow: 0 0 0 1px rgba(14, 165, 233, 0.2);
+}
+
+.group-layout-divider-strip.active::before {
+    background: var(--hmi-success);
+    box-shadow: 0 0 10px rgba(16, 185, 129, 0.35);
+}
+
+.group-layout-divider-strip.vertical {
+    margin: 0;
+}
+
+.group-layout-divider-strip.horizontal {
+    margin: 0;
+}
+
+.group-layout-divider-strip.vertical::before {
+    top: 6px;
+    bottom: 6px;
+    left: 50%;
+    width: 8px;
+    transform: translateX(-50%);
+}
+
+.group-layout-divider-strip.horizontal::before {
+    left: 6px;
+    right: 6px;
+    top: 50%;
+    height: 8px;
+    transform: translateY(-50%);
+}
+
+.group-layout-add-row-btn {
+    width: 100%;
+    margin-top: 12px;
+    padding: 10px 14px;
+    border: 1px solid rgba(16, 185, 129, 0.55);
+    border-radius: 8px;
+    background: linear-gradient(135deg, #16a34a 0%, #22c55e 100%);
+    color: white;
+    font-weight: 800;
+    box-shadow: 0 2px 8px rgba(16, 185, 129, 0.25);
+}
+
+.group-layout-add-row-btn:hover {
+    background: linear-gradient(135deg, #15803d 0%, #16a34a 100%);
+}
+
+@media (max-width: 640px) {
+    .group-layout-position-item {
+        grid-template-columns: 1fr;
+    }
+
+    .group-item-actions {
+        flex-direction: column;
+    }
 }
 
 .routine-steps {
@@ -1690,6 +1967,120 @@ select option[disabled] {
     flex-wrap: wrap;
 }
 
+.control-view-card {
+    margin-bottom: 16px;
+}
+
+.control-view-toggle {
+    display: inline-flex;
+    gap: 6px;
+    padding: 4px;
+    background: var(--hmi-bg-alt);
+    border: 1px solid var(--hmi-border);
+    border-radius: 10px;
+}
+
+.control-view-toggle-btn {
+    border: none;
+    border-radius: 8px;
+    min-width: 116px;
+    padding: 10px 16px;
+    background: transparent;
+    color: var(--hmi-text-muted);
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.control-view-toggle-btn:hover {
+    color: var(--hmi-text);
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.control-view-toggle-btn.active {
+    background: linear-gradient(135deg, rgba(37, 99, 235, 0.28), rgba(14, 165, 233, 0.18));
+    color: #dbeafe;
+    box-shadow: 0 2px 8px rgba(37, 99, 235, 0.2);
+}
+
+.group-layout-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.group-layout-subtitle {
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--hmi-text-muted);
+}
+
+.group-layout-grid {
+    display: grid;
+    gap: 16px;
+    align-items: start;
+}
+
+.group-layout-grid.with-dividers {
+    gap: 0;
+}
+
+.group-layout-grid.with-dividers .group-layout-cell {
+    padding: 0;
+    position: relative;
+    z-index: 1;
+}
+
+.group-layout-cell {
+    min-width: 0;
+}
+
+
+
+.group-layout-view-divider {
+    align-self: stretch;
+    justify-self: stretch;
+    position: relative;
+    z-index: 3;
+    border-radius: 99px;
+    background:  rgb(118, 129, 152);
+    box-shadow: none;
+    pointer-events: none;
+}
+
+.group-layout-view-divider.vertical {
+    width: 7px;
+    margin: 0 auto;
+}
+
+.group-layout-view-divider.horizontal {
+    height: 7px;
+    margin: auto 0;
+}
+
+.group-layout-view-divider.intersection {
+    z-index: 4;
+    border-radius: 0px;
+}
+
+.group-layout-view-divider.intersection.horizontal {
+    width: 500%;
+    left: 30%;
+    margin-left: -85%;
+}
+
+.group-layout-view-divider.intersection.vertical {
+    height: 180%;
+    top: 00%;
+    margin-top: -25%;
+}
+
+.group-layout-empty {
+    color: var(--hmi-text-muted);
+    font-size: 13px;
+}
+
 /* Sensor visibility and graph controls */
 .sensor-visibility-controls {
     display: flex;
@@ -1722,18 +2113,8 @@ select option[disabled] {
     background: rgba(37, 99, 235, 0.18);
 }
 
-.sensor-graph-controls {
-    margin-top: 10px;
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    padding-right: 4px;
-}
-
 .sensor-graph-select {
-    min-width: 260px;
+    min-width: 240px;
     max-width: 100%;
     width: min(420px, 100%);
     padding: 8px 10px;
@@ -1741,6 +2122,100 @@ select option[disabled] {
     border-radius: 8px;
     background: var(--hmi-bg-alt);
     color: var(--hmi-text);
+}
+
+.sensor-dashboard-row {
+    display: grid;
+    grid-template-columns: minmax(360px, 0.85fr) minmax(520px, 1.4fr);
+    gap: 20px;
+    align-items: stretch;
+    margin-top: 20px;
+}
+
+.sensor-dashboard-row.metrics-only {
+    grid-template-columns: minmax(0, 1fr);
+}
+
+.sensor-metrics-panel,
+.sensor-graph-panel {
+    margin-top: 0;
+}
+
+.sensor-metrics-grid {
+    padding: 12px 16px;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 10px 14px;
+}
+
+.sensor-metrics-empty {
+    grid-column: 1 / span 2;
+    color: var(--hmi-text-muted);
+}
+
+.sensor-metric-name {
+    min-width: 0;
+    color: #e5e7eb;
+}
+
+.sensor-metric-value {
+    color: #f9fafb;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+}
+
+.live-graph-section {
+    padding-bottom: 16px;
+}
+
+.live-graph-header {
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.live-graph-toolbar {
+    margin-left: auto;
+}
+
+.sensor-graph-controls-inline {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+
+.live-graph-chart {
+    padding: 10px 20px 8px 0;
+}
+
+.live-graph-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--hmi-text-muted);
+}
+
+@media (max-width: 1180px) {
+    .sensor-dashboard-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 900px) {
+    .side-panel-resize-handle {
+        display: none;
+    }
+
+    .hmi-control-select,
+    .hmi-group-select {
+        width: 100%;
+        min-width: min(260px, 100%);
+    }
+
+    .sensor-graph-controls-inline {
+        justify-content: flex-start;
+    }
 }
 
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -6,10 +6,34 @@ export type Panel = {
     last_change_ts: number;
 };
 
+export type GroupLayoutItem = {
+    panel_id: string;
+    row: number;
+    column: number;
+};
+
+export type GroupLayoutDivider = {
+    row: number;
+    column: number;
+};
+
+export type GroupLayoutDividers = {
+    vertical: GroupLayoutDivider[];
+    horizontal: GroupLayoutDivider[];
+};
+
+export type GroupLayout = {
+    columns: number;
+    rows?: number | null;
+    items: GroupLayoutItem[];
+    dividers?: GroupLayoutDividers | null;
+};
+
 export type Group = {
     id: string;
     name: string;
     member_ids: string[];
+    layout?: GroupLayout | null;
 };
 
 export type AuditLogEntry = {

--- a/web/src/utils/groupLayout.test.ts
+++ b/web/src/utils/groupLayout.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDefaultGroupLayout, normalizeGroupLayout } from "./groupLayout";
+
+describe("groupLayout utilities", () => {
+    it("builds a default layout in row-major order", () => {
+        expect(buildDefaultGroupLayout(["P01", "P02", "P03"], 2)).toEqual({
+            columns: 2,
+            items: [
+                { panel_id: "P01", row: 1, column: 1 },
+                { panel_id: "P02", row: 1, column: 2 },
+                { panel_id: "P03", row: 2, column: 1 },
+            ],
+        });
+    });
+
+    it("normalizes collisions and fills missing member positions", () => {
+        expect(
+            normalizeGroupLayout(["P01", "P02", "P03"], {
+                columns: 2,
+                items: [
+                    { panel_id: "P01", row: 1, column: 1 },
+                    { panel_id: "P02", row: 1, column: 1 },
+                ],
+            }),
+        ).toEqual({
+            columns: 2,
+            items: [
+                { panel_id: "P01", row: 1, column: 1 },
+                { panel_id: "P02", row: 1, column: 2 },
+                { panel_id: "P03", row: 2, column: 1 },
+            ],
+        });
+    });
+
+    it("caps layouts at eight columns", () => {
+        expect(buildDefaultGroupLayout(["P01"], 12)?.columns).toBe(8);
+        expect(normalizeGroupLayout(["P01"], { columns: 12, items: [] })?.columns).toBe(8);
+    });
+
+    it("preserves explicit empty rows", () => {
+        expect(
+            normalizeGroupLayout(["P01"], {
+                columns: 2,
+                rows: 3,
+                items: [{ panel_id: "P01", row: 1, column: 1 }],
+            }),
+        ).toEqual({
+            columns: 2,
+            rows: 3,
+            items: [{ panel_id: "P01", row: 1, column: 1 }],
+        });
+    });
+
+    it("normalizes divider metadata inside the saved layout bounds", () => {
+        expect(
+            normalizeGroupLayout(["P01", "P02"], {
+                columns: 2,
+                rows: 2,
+                items: [
+                    { panel_id: "P01", row: 1, column: 1 },
+                    { panel_id: "P02", row: 1, column: 2 },
+                ],
+                dividers: {
+                    vertical: [
+                        { row: 1, column: 1 },
+                        { row: 1, column: 1 },
+                        { row: 3, column: 1 },
+                    ],
+                    horizontal: [
+                        { row: 1, column: 1 },
+                        { row: 1, column: 3 },
+                    ],
+                },
+            }),
+        ).toEqual({
+            columns: 2,
+            rows: 2,
+            items: [
+                { panel_id: "P01", row: 1, column: 1 },
+                { panel_id: "P02", row: 1, column: 2 },
+            ],
+            dividers: {
+                vertical: [{ row: 1, column: 1 }],
+                horizontal: [{ row: 1, column: 1 }],
+            },
+        });
+    });
+});

--- a/web/src/utils/groupLayout.ts
+++ b/web/src/utils/groupLayout.ts
@@ -1,0 +1,155 @@
+import type { GroupLayout, GroupLayoutDivider, GroupLayoutDividers, GroupLayoutItem } from "../types";
+
+export const DEFAULT_GROUP_LAYOUT_COLUMNS = 4;
+export const MAX_GROUP_LAYOUT_COLUMNS = 8;
+
+function uniquePanelIds(panelIds: string[]): string[] {
+    const seen = new Set<string>();
+    const uniqueIds: string[] = [];
+    for (const panelId of panelIds) {
+        const normalized = panelId.trim();
+        if (!normalized || seen.has(normalized)) continue;
+        seen.add(normalized);
+        uniqueIds.push(normalized);
+    }
+    return uniqueIds;
+}
+
+function normalizeColumns(columns?: number | null): number {
+    return Math.max(1, Math.min(MAX_GROUP_LAYOUT_COLUMNS, Math.floor(columns || DEFAULT_GROUP_LAYOUT_COLUMNS)));
+}
+
+function normalizePositiveInteger(value: number | null | undefined): number | null {
+    if (!Number.isFinite(value ?? NaN)) return null;
+    return Math.max(1, Math.floor(value as number));
+}
+
+function uniqueDividers(
+    dividers: GroupLayoutDivider[] | undefined,
+    maxRow: number,
+    maxColumn: number,
+): GroupLayoutDivider[] {
+    if (!dividers?.length || maxRow < 1 || maxColumn < 1) return [];
+
+    const seen = new Set<string>();
+    const result: GroupLayoutDivider[] = [];
+    for (const divider of dividers) {
+        const row = normalizePositiveInteger(divider.row);
+        const column = normalizePositiveInteger(divider.column);
+        if (row == null || column == null || row > maxRow || column > maxColumn) continue;
+
+        const key = `${row}:${column}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        result.push({ row, column });
+    }
+
+    return result.sort((a, b) => a.row - b.row || a.column - b.column);
+}
+
+function normalizeDividers(
+    dividers: GroupLayoutDividers | null | undefined,
+    rows: number,
+    columns: number,
+): GroupLayoutDividers | undefined {
+    const vertical = uniqueDividers(dividers?.vertical, rows, columns - 1);
+    const horizontal = uniqueDividers(dividers?.horizontal, rows - 1, columns);
+    if (!vertical.length && !horizontal.length) return undefined;
+    return { vertical, horizontal };
+}
+
+export function buildDefaultGroupLayout(
+    panelIds: string[],
+    columns = DEFAULT_GROUP_LAYOUT_COLUMNS,
+): GroupLayout | null {
+    const uniqueIds = uniquePanelIds(panelIds);
+    if (!uniqueIds.length) return null;
+
+    const normalizedColumns = normalizeColumns(columns);
+    return {
+        columns: normalizedColumns,
+        items: uniqueIds.map((panelId, index) => ({
+            panel_id: panelId,
+            row: Math.floor(index / normalizedColumns) + 1,
+            column: (index % normalizedColumns) + 1,
+        })),
+    };
+}
+
+export function normalizeGroupLayout(
+    panelIds: string[],
+    layout?: GroupLayout | null,
+): GroupLayout | null {
+    const uniqueIds = uniquePanelIds(panelIds);
+    if (!uniqueIds.length) return null;
+    if (!layout) return buildDefaultGroupLayout(uniqueIds);
+
+    const columns = normalizeColumns(layout.columns);
+    const validIds = new Set(uniqueIds);
+    const positions = new Map<string, { row: number; column: number }>();
+    const occupied = new Set<string>();
+
+    for (const item of layout.items) {
+        const panelId = item.panel_id.trim();
+        if (!validIds.has(panelId) || positions.has(panelId)) continue;
+
+        let row = Math.max(1, Math.floor(item.row || 1));
+        let column = Math.max(1, Math.min(columns, Math.floor(item.column || 1)));
+        while (occupied.has(`${row}:${column}`)) {
+            column += 1;
+            if (column > columns) {
+                column = 1;
+                row += 1;
+            }
+        }
+
+        positions.set(panelId, { row, column });
+        occupied.add(`${row}:${column}`);
+    }
+
+    let nextRow = 1;
+    let nextColumn = 1;
+    const nextAvailablePosition = () => {
+        while (occupied.has(`${nextRow}:${nextColumn}`)) {
+            nextColumn += 1;
+            if (nextColumn > columns) {
+                nextColumn = 1;
+                nextRow += 1;
+            }
+        }
+        occupied.add(`${nextRow}:${nextColumn}`);
+        return { row: nextRow, column: nextColumn };
+    };
+
+    const items: GroupLayoutItem[] = uniqueIds.map(panelId => {
+        const position = positions.get(panelId) ?? nextAvailablePosition();
+        return {
+            panel_id: panelId,
+            row: position.row,
+            column: position.column,
+        };
+    });
+
+    const minimumRows = Math.max(
+        1,
+        Math.ceil(uniqueIds.length / columns),
+        ...items.map(item => item.row),
+    );
+    const explicitRows = normalizePositiveInteger(layout.rows);
+    const rows = Math.max(minimumRows, explicitRows ?? minimumRows);
+    const dividers = normalizeDividers(layout.dividers, rows, columns);
+    const normalizedLayout: GroupLayout = { columns, items };
+
+    if (explicitRows != null && rows > minimumRows) {
+        normalizedLayout.rows = rows;
+    }
+    if (dividers) {
+        normalizedLayout.dividers = dividers;
+    }
+
+    return normalizedLayout;
+}
+
+export function layoutItemMap(layout?: GroupLayout | null): Map<string, GroupLayoutItem> {
+    return new Map((layout?.items || []).map(item => [item.panel_id, item]));
+}

--- a/web/src/utils/panelSort.ts
+++ b/web/src/utils/panelSort.ts
@@ -1,0 +1,27 @@
+import type { Panel } from "../types";
+
+function panelSortKey(panel: Panel): { prefix: string; number: number; label: string } {
+    const idMatch = panel.id.match(/^([A-Za-z]+)(\d+)$/);
+    const nameMatch = panel.name.match(/^(.*?)(\d+)$/);
+    const match = idMatch || nameMatch;
+    if (!match) {
+        return { prefix: panel.name.toLowerCase(), number: Number.POSITIVE_INFINITY, label: panel.name.toLowerCase() };
+    }
+
+    return {
+        prefix: match[1].toLowerCase(),
+        number: Number(match[2]),
+        label: panel.name.toLowerCase(),
+    };
+}
+
+export function sortPanelsByNumber(panels: Panel[]): Panel[] {
+    return [...panels].sort((a, b) => {
+        const aKey = panelSortKey(a);
+        const bKey = panelSortKey(b);
+        const prefixCompare = aKey.prefix.localeCompare(bKey.prefix);
+        if (prefixCompare !== 0) return prefixCompare;
+        if (aKey.number !== bKey.number) return aKey.number - bKey.number;
+        return aKey.label.localeCompare(bKey.label);
+    });
+}


### PR DESCRIPTION
## Summary
Adds customizable panel organization with List View and Group View, including persisted 2D group layouts. Users can create/edit groups, arrange panels visually, add layout rows, configure dividers, and view selected groups in a custom layout. This also updates group layout persistence across the frontend, simulator, real-mode overlay, and SQLite storage.

## Type
- [x] Feature
- [x] Fix
- [ ] Docs
- [ ] Chore

## Testing
- `npm run typecheck`
- `npm test`
- `npm run build`
- `uv run pytest -q`

Also added or updated tests for:

- Group layout normalization
- Group API layout round trips
- SQLite persistence
- Real-mode saved layout overlay
- API group layout payloads

## Risk and rollout
Risk is mostly around layout metadata compatibility with existing saved groups and UI rendering edge cases for custom layouts. Rollback plan is to revert this commit; existing flat/list panel controls should remain available if users do not use custom group layouts.

## Checklist
- [ ] Issue linked if applicable
- [ ] Added or updated docs
- [x] CI green
- [ ] At least one reviewer not the author
