### PR TITLE
feat(sensors): add support for file mode for multiple Jeti sensors (Spectraval and Specbos)

### DIFF
--- a/docs/on_site_sensor_checklist.md
+++ b/docs/on_site_sensor_checklist.md
@@ -27,7 +27,8 @@ Use this at the trailer/lab PC after the hardware is physically installed.
 1. Set `t10a[].port` to the actual T-10A COM port.
 2. Set `t10a[].heads[].head_no` to the actual physical T-10A adaptor/head ID.
 3. Set `jeti_spectraval[].transport` to either `file` or `serial_scpi`.
-4. If JETI uses file mode, set `jeti_spectraval[].output_path` to the actual live `.cap` file or folder.
+4. If JETI uses file mode, set `jeti_spectraval[].output_path` to the actual live `.cap` file.
+   **REQUIREMENT**: When configuring multiple JETI sensors (Spectraval or Specbos) in file mode, you MUST configure the Jeti software to export each sensor's data to a distinct file name (e.g., `spectraval_1.cap`, `specbos.cap`). Do not point multiple sensors to the same file, as this will cause data collisions.
 5. If JETI uses serial mode, set `jeti_spectraval[].port` to the JETI COM port.
 6. If JETI uses serial mode, set `jeti_spectraval[].baudrate`:
    - `921600` for `spectraval 1511`

--- a/svc/data/sensors_config.json
+++ b/svc/data/sensors_config.json
@@ -77,16 +77,40 @@
   ],
   "jeti_spectraval": [
     {
-      "sensor_id": "JETI-00",
-      "device_id": "JETI",
+      "sensor_id": "SPECTRAVAL-1",
+      "device_id": "JETI-SV-1",
       "transport": "file",
       "template_path": "data/251118_Jeti_Spectraval_Data.cap",
-      "output_path": "data/jeti_sim_output",
+      "output_path": "data/spectraval_1.cap",
       "watch_interval_s": 1,
       "interval_s": 5,
       "loop": true,
-      "label": "Jeti Spectraval",
-      "location": null
+      "label": "Spectraval #1",
+      "location": "Inside"
+    },
+    {
+      "sensor_id": "SPECTRAVAL-2",
+      "device_id": "JETI-SV-2",
+      "transport": "file",
+      "template_path": "data/251118_Jeti_Spectraval_Data.cap",
+      "output_path": "data/spectraval_2.cap",
+      "watch_interval_s": 1,
+      "interval_s": 5,
+      "loop": true,
+      "label": "Spectraval #2",
+      "location": "Outside"
+    },
+    {
+      "sensor_id": "SPECBOS-1",
+      "device_id": "JETI-SB-1",
+      "transport": "file",
+      "template_path": "data/251118_Jeti_Spectraval_Data.cap",
+      "output_path": "data/specbos.cap",
+      "watch_interval_s": 1,
+      "interval_s": 5,
+      "loop": true,
+      "label": "Specbos 1211",
+      "location": "Reference"
     }
   ],
   "eko_ms90_plus": [

--- a/web/src/components/RoutineCodeEditor.tsx
+++ b/web/src/components/RoutineCodeEditor.tsx
@@ -44,7 +44,7 @@ if ghi is not None and sun_elev is not None:
     },
     {
         label: "Research: Melanopic EDI limits with JETI",
-        code: `mel_edi = sensors.get_latest("JETI-00", "melanopic_edi_lx")
+        code: `mel_edi = sensors.get_latest("SPECTRAVAL-1", "melanopic_edi_lx")
 sun_elev = sensors.get_latest("EKO-00", "sun_elevation_deg")
 
 log(f"Melanopic EDI: {mel_edi} lx")
@@ -61,7 +61,7 @@ if mel_edi is not None:
     },
     {
         label: "Color Quality: Maintain minimum CRI",
-        code: `cri = sensors.get_latest("JETI-00", "cri_ra")
+        code: `cri = sensors.get_latest("SPECTRAVAL-1", "cri_ra")
 lux = sensors.get_latest("T10A1-H1", "lux")
 
 log(f"CRI (Ra): {cri}, Lux: {lux}")

--- a/web/src/components/RoutineDocs.tsx
+++ b/web/src/components/RoutineDocs.tsx
@@ -165,7 +165,8 @@ for s in sensor_list:
                         <p style={{ lineHeight: "1.6", marginBottom: "8px" }}>Provides advanced colorimetry, illuminance, and non-visual lighting metrics from JETI spectraval or specbos devices.</p>
                         <h4 style={{ color: "var(--hmi-text-muted)", marginBottom: "4px" }}>Common Sensor IDs:</h4>
                         <ul style={{ margin: "0 0 12px 0", paddingLeft: "20px" }}>
-                            <li><code>JETI-00</code> - first configured JETI device</li>
+                            <li><code>SPECTRAVAL-1</code> - first configured Spectraval device</li>
+                            <li><code>SPECBOS-1</code> - configured Specbos device</li>
                         </ul>
                         <h4 style={{ color: "var(--hmi-text-muted)", marginBottom: "4px" }}>Available Metrics:</h4>
                         <ul style={{ margin: 0, paddingLeft: "20px", display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: "4px" }}>


### PR DESCRIPTION
## Summary

- Expanded to track two Spectravals and one Specbos independently with distinct file paths.
- Updated the on-site sensor checklist to enforce distinct file name requirements for Jeti software exports to prevent data collisions.
- Replaced outdated placeholders with and in the Routine Editor examples and documentation to match the new configuration.

## Type
- [x] Feature
- [ ] Fix
- [x] Docs
- [ ] Chore

## Testing
No functional changes, just docs and config, no testing needed.

## Risk and rollout
rollback if it doesn't work at the trailer visit

## Checklist
- [ ] Issue linked if applicable
- [x] Added or updated docs
- [x] CI green
- [x] At least one reviewer not the author
