### PR TITLE
added support for spectral irridiance graph to be viewed live and log view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ svc/data/jeti_sim_output/
 
 # Local temporary research repo / scratch workspace
 /.tmp_luox/
+*.cap

--- a/svc/app/models.py
+++ b/svc/app/models.py
@@ -101,6 +101,15 @@ class SensorLogEntry(BaseModel):
     ts: float
 
 
+class SensorSpectrumResponse(BaseModel):
+    sensor_id: str
+    ts: float
+    wavelength_start: int
+    wavelength_end: int
+    wavelength_step: int
+    values: List[float]
+
+
 class RoutineRequest(BaseModel):
     name: str = Field(description="Name of the routine")
     code: str = Field(description="Python code to execute")

--- a/svc/app/routes.py
+++ b/svc/app/routes.py
@@ -4,7 +4,8 @@ from fastapi.responses import Response
 from .models import (
     Panel, Group, CommandRequest, CommandResult, GroupCreate, GroupUpdate, 
     AuditEntry, HealthResponse, DeleteGroupResponse, ErrorResponse, SensorInfo,
-    SensorReadingResponse, SensorLogEntry, RoutineRequest, RoutineStatusResponse, SavedRoutine
+    SensorReadingResponse, SensorLogEntry, RoutineRequest, RoutineStatusResponse, SavedRoutine,
+    SensorSpectrumResponse
 )
 from typing import List, Optional
 import csv
@@ -22,7 +23,9 @@ from .state import (
     get_routine,
     list_saved_routines,
     save_saved_routine,
-    delete_saved_routine
+    delete_saved_routine,
+    fetch_latest_spectrum,
+    fetch_historical_spectrum
 )
 from .routines.manager import start_routine, stop_routine, remove_routine, active_routines
 import uuid
@@ -465,6 +468,35 @@ def get_metric_history(
 ) -> List[SensorReadingResponse]:
     rows = _fetch_readings(sensor_id=sensor_id, metric=metric, ts_from=ts_from, ts_to=ts_to)
     return [SensorReadingResponse(**r) for r in rows]
+
+
+@router.get(
+    "/sensors/{sensor_id}/spectrum/latest",
+    response_model=SensorSpectrumResponse,
+    summary="Latest spectrum for a sensor",
+    tags=["Sensors"],
+)
+def get_latest_spectrum(sensor_id: str) -> SensorSpectrumResponse:
+    res = fetch_latest_spectrum(sensor_id)
+    if not res:
+        raise HTTPException(status_code=404, detail="No spectrum found for this sensor")
+    return SensorSpectrumResponse(**res)
+
+
+@router.get(
+    "/sensors/{sensor_id}/spectrum/historical",
+    response_model=SensorSpectrumResponse,
+    summary="Historical spectrum for a sensor",
+    tags=["Sensors"],
+)
+def get_historical_spectrum(
+    sensor_id: str,
+    ts: float = Query(..., description="Timestamp of the reading"),
+) -> SensorSpectrumResponse:
+    res = fetch_historical_spectrum(sensor_id, ts)
+    if not res:
+        raise HTTPException(status_code=404, detail="No spectrum found for this sensor at this timestamp")
+    return SensorSpectrumResponse(**res)
 
 
 # --- ROUTINES -------------------------------------------------------------

--- a/svc/app/sensors/interface.py
+++ b/svc/app/sensors/interface.py
@@ -10,6 +10,7 @@ class SensorReading:
     metric: str         # e.g. "lux"
     value: float
     ts: float           # unix timestamp
+    spectrum: list[float] | None = None
 
 
 class SensorClient(Protocol):

--- a/svc/app/sensors/jeti_specfirm_client.py
+++ b/svc/app/sensors/jeti_specfirm_client.py
@@ -209,7 +209,15 @@ class JetiSpecfirmClient(SensorClient):
 
             metrics = compute_jeti_metrics(lux=lux, spectral_values=spectral)
             ts = time.time()
-            out: list[SensorReading] = []
+            out: list[SensorReading] = [
+                SensorReading(
+                    sensor_id=self._sensor_id,
+                    metric="spectrum",
+                    value=0.0,
+                    ts=ts,
+                    spectrum=spectral,
+                )
+            ]
             for metric, value in metrics.items():
                 out.append(
                     SensorReading(

--- a/svc/app/sensors/jeti_spectraval_watcher.py
+++ b/svc/app/sensors/jeti_spectraval_watcher.py
@@ -5,7 +5,7 @@ import time
 from datetime import datetime
 from typing import Iterable, List, Tuple
 from .interface import SensorClient, SensorReading
-from .spectral_metrics import compute_jeti_metrics
+from .spectral_metrics import compute_jeti_metrics, _clean_spectral_values
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +174,17 @@ class JetiSpectravalFileWatcher(SensorClient):
                         if dt > 0:
                             metrics["sample_interval_s"] = dt
                     self._last_measurement_ts = measurement_ts
+
+                    # Clean raw spectral strings and yield a spectrum reading
+                    cleaned_spec = _clean_spectral_values(spectral)
+                    if cleaned_spec:
+                        yield SensorReading(
+                            sensor_id=self._sensor_id,
+                            metric="spectrum",
+                            value=0.0,
+                            ts=measurement_ts,
+                            spectrum=cleaned_spec,
+                        )
 
                     if not metrics:
                         continue

--- a/svc/app/sensors/manager.py
+++ b/svc/app/sensors/manager.py
@@ -12,6 +12,7 @@ from app.config import MODE
 from app.state import (
     delete_sensor_readings_for_ids,
     insert_sensor_reading,
+    insert_sensor_spectrum,
     prune_sensors_to_ids,
     register_sensor,
 )
@@ -436,7 +437,10 @@ def _worker_loop(client: SensorClient, interval_s: float) -> None:
         if readings:
             logger.debug(f"Manager: received {len(readings)} readings from {client}")
         for r in readings:
-            insert_sensor_reading(r.sensor_id, r.ts, r.metric, r.value)
+            if r.metric == "spectrum" and r.spectrum is not None:
+                insert_sensor_spectrum(r.sensor_id, r.ts, r.spectrum)
+            else:
+                insert_sensor_reading(r.sensor_id, r.ts, r.metric, r.value)
         if _stop_flag:
             break
         time.sleep(interval_s)

--- a/svc/app/state.py
+++ b/svc/app/state.py
@@ -609,7 +609,7 @@ def fetch_latest_readings() -> list[dict]:
 
 
 def delete_sensor_readings_for_ids(sensor_ids: list[str]) -> None:
-    """Delete all readings for the provided sensor IDs."""
+    """Delete all readings and spectra for the provided sensor IDs."""
     _ensure_sensor_db()
     unique_ids = sorted(set(sensor_ids))
     if not unique_ids:
@@ -617,6 +617,10 @@ def delete_sensor_readings_for_ids(sensor_ids: list[str]) -> None:
 
     placeholders = ",".join(["?"] * len(unique_ids))
     with _db_connection() as conn:
+        conn.execute(
+            f"DELETE FROM sensor_spectra WHERE sensor_id IN ({placeholders})",
+            tuple(unique_ids),
+        )
         conn.execute(
             f"DELETE FROM sensor_readings WHERE sensor_id IN ({placeholders})",
             tuple(unique_ids),
@@ -746,11 +750,16 @@ def prune_sensors_to_ids(sensor_ids: list[str]) -> None:
     unique_ids = sorted(set(sensor_ids))
     with _db_connection() as conn:
         if not unique_ids:
+            conn.execute("DELETE FROM sensor_spectra")
             conn.execute("DELETE FROM sensor_readings")
             conn.execute("DELETE FROM sensors")
             return
 
         placeholders = ",".join(["?"] * len(unique_ids))
+        conn.execute(
+            f"DELETE FROM sensor_spectra WHERE sensor_id NOT IN ({placeholders})",
+            tuple(unique_ids),
+        )
         conn.execute(
             f"DELETE FROM sensor_readings WHERE sensor_id NOT IN ({placeholders})",
             tuple(unique_ids),

--- a/svc/app/state.py
+++ b/svc/app/state.py
@@ -449,6 +449,20 @@ def _ensure_sensor_db() -> None:
         )
         conn.execute(
             """
+            CREATE TABLE IF NOT EXISTS sensor_spectra (
+                sensor_id TEXT NOT NULL,
+                ts REAL NOT NULL,
+                wavelength_start INTEGER NOT NULL,
+                wavelength_end INTEGER NOT NULL,
+                wavelength_step INTEGER NOT NULL,
+                values_json TEXT NOT NULL,
+                PRIMARY KEY (sensor_id, ts),
+                FOREIGN KEY(sensor_id) REFERENCES sensors(id)
+            )
+            """
+        )
+        conn.execute(
+            """
             CREATE INDEX IF NOT EXISTS idx_sensor_readings_sensor_metric_ts
             ON sensor_readings (sensor_id, metric, ts)
             """
@@ -504,6 +518,70 @@ def insert_sensor_reading(
             """,
             (sensor_id, ts, metric, value),
         )
+
+
+def insert_sensor_spectrum(
+    sensor_id: str,
+    ts: float,
+    spectrum: list[float],
+    wavelength_start: int = 380,
+    wavelength_step: int = 1,
+) -> None:
+    """Insert a sensor spectrum measurement."""
+    _ensure_sensor_db()
+    wavelength_end = wavelength_start + len(spectrum) - 1
+    values_json = json.dumps(spectrum)
+    with _db_connection() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO sensor_spectra (
+                sensor_id, ts, wavelength_start, wavelength_end, wavelength_step, values_json
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (sensor_id, ts, wavelength_start, wavelength_end, wavelength_step, values_json),
+        )
+
+
+def fetch_latest_spectrum(sensor_id: str) -> dict | None:
+    """Fetch the latest spectrum for a given sensor."""
+    _ensure_sensor_db()
+    with _db_connection(row_factory=sqlite3.Row) as conn:
+        row = conn.execute(
+            """
+            SELECT sensor_id, ts, wavelength_start, wavelength_end, wavelength_step, values_json
+            FROM sensor_spectra
+            WHERE sensor_id = ?
+            ORDER BY ts DESC
+            LIMIT 1
+            """,
+            (sensor_id,),
+        ).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        d["values"] = json.loads(d.pop("values_json"))
+        return d
+
+
+def fetch_historical_spectrum(sensor_id: str, ts: float) -> dict | None:
+    """Fetch the historical spectrum for a sensor closest to a given timestamp."""
+    _ensure_sensor_db()
+    with _db_connection(row_factory=sqlite3.Row) as conn:
+        row = conn.execute(
+            """
+            SELECT sensor_id, ts, wavelength_start, wavelength_end, wavelength_step, values_json
+            FROM sensor_spectra
+            WHERE sensor_id = ? AND ABS(ts - ?) < 0.1
+            ORDER BY ABS(ts - ?)
+            LIMIT 1
+            """,
+            (sensor_id, ts, ts),
+        ).fetchone()
+        if not row:
+            return None
+        d = dict(row)
+        d["values"] = json.loads(d.pop("values_json"))
+        return d
 
 
 def fetch_latest_readings() -> list[dict]:

--- a/svc/tests/test_jeti_specfirm_client.py
+++ b/svc/tests/test_jeti_specfirm_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import app.sensors.jeti_specfirm_client as specfirm
 from app.sensors.jeti_specfirm_client import JetiSpecfirmClient
 
 
@@ -40,3 +41,41 @@ def test_extract_spectrum_values_falls_back_to_flat_float_stream() -> None:
 
     vals = c._extract_spectrum_values(raw)
     assert vals == [10.0, 20.0, 30.0]
+
+
+def test_poll_returns_raw_spectrum_reading(monkeypatch) -> None:
+    c = JetiSpecfirmClient.__new__(JetiSpecfirmClient)
+    c.id = "JETI"
+    c._sensor_id = "JETI-00"
+    c._configured = True
+    c._tint_ms = 100
+    c._avg_count = 1
+    c._w_start = 380
+    c._w_end = 389
+    c._w_step = 1
+    c._expected_samples = 10
+
+    spectral_values = [float(i) for i in range(10)]
+    spectral_response = "\r".join(
+        f"{380 + idx}\t{value}" for idx, value in enumerate(spectral_values)
+    ).encode("ascii")
+    responses = [spectral_response, b"12.3"]
+
+    def fake_send(*_args, **_kwargs):
+        return responses.pop(0)
+
+    c._send = fake_send
+    monkeypatch.setattr(
+        specfirm,
+        "compute_jeti_metrics",
+        lambda lux, spectral_values: {"lux": 12.3},
+    )
+
+    readings = list(c.poll())
+
+    spectrum_readings = [r for r in readings if r.metric == "spectrum"]
+    assert len(spectrum_readings) == 1
+    assert spectrum_readings[0].sensor_id == "JETI-00"
+    assert spectrum_readings[0].value == 0.0
+    assert spectrum_readings[0].spectrum == spectral_values
+    assert any(r.metric == "lux" and r.value == 12.3 for r in readings)

--- a/svc/tests/test_sensor_spectrum.py
+++ b/svc/tests/test_sensor_spectrum.py
@@ -1,0 +1,108 @@
+import os
+import sqlite3
+import time
+from fastapi.testclient import TestClient
+import pytest
+from app.sensors.interface import SensorReading
+from app.sensors.jeti_spectraval_watcher import JetiSpectravalFileWatcher
+from app.state import (
+    _db_connection,
+    _ensure_sensor_db,
+    insert_sensor_spectrum,
+    fetch_latest_spectrum,
+    fetch_historical_spectrum,
+)
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def temp_db(tmp_path, monkeypatch):
+    """Create a temporary database file for testing."""
+    db_file = tmp_path / "test_audit.db"
+    monkeypatch.setattr("app.state.AUDIT_DB_FILE", str(db_file))
+    monkeypatch.setattr("app.config.AUDIT_DB_FILE", str(db_file))
+    
+    if db_file.exists():
+        db_file.unlink()
+    
+    yield str(db_file)
+    
+    if db_file.exists():
+        db_file.unlink()
+
+
+def test_sqlite_spectrum_operations():
+    # Verify insert and fetch latest
+    insert_sensor_spectrum("JETI-TEST", 1000.0, [1.0, 2.0, 3.0])
+    latest = fetch_latest_spectrum("JETI-TEST")
+    assert latest is not None
+    assert latest["sensor_id"] == "JETI-TEST"
+    assert latest["ts"] == 1000.0
+    assert latest["wavelength_start"] == 380
+    assert latest["wavelength_end"] == 382
+    assert latest["wavelength_step"] == 1
+    assert latest["values"] == [1.0, 2.0, 3.0]
+
+    # Verify fetch historical close match
+    hist = fetch_historical_spectrum("JETI-TEST", 1000.05)
+    assert hist is not None
+    assert hist["ts"] == 1000.0
+
+    # Verify no match for far away timestamp
+    hist_far = fetch_historical_spectrum("JETI-TEST", 1005.0)
+    assert hist_far is None
+
+
+def test_api_spectrum_endpoints():
+    # Insert test data
+    insert_sensor_spectrum("JETI-TEST", 2000.0, [10.0, 20.0, 30.0])
+
+    # Latest endpoint
+    response = client.get("/sensors/JETI-TEST/spectrum/latest")
+    assert response.status_code == 200
+    res_data = response.json()
+    assert res_data["sensor_id"] == "JETI-TEST"
+    assert res_data["ts"] == 2000.0
+    assert res_data["values"] == [10.0, 20.0, 30.0]
+
+    # Historical endpoint
+    response_hist = client.get("/sensors/JETI-TEST/spectrum/historical?ts=2000.02")
+    assert response_hist.status_code == 200
+    res_hist_data = response_hist.json()
+    assert res_hist_data["sensor_id"] == "JETI-TEST"
+    assert res_hist_data["ts"] == 2000.0
+
+    # Non-existent sensor / timestamp
+    response_none = client.get("/sensors/NON-EXISTENT/spectrum/latest")
+    assert response_none.status_code == 404
+
+
+def test_watcher_yields_spectrum(tmp_path):
+    output_dir = tmp_path / "jeti_output"
+    output_dir.mkdir()
+    cap_file = output_dir / "latest.cap"
+
+    watcher = JetiSpectravalFileWatcher(
+        device_id="JETI",
+        sensor_id="JETI-00",
+        input_path=str(cap_file),
+        label="JETI",
+        svc_root=str(tmp_path),
+    )
+
+    # Initial poll when file does not exist should be empty
+    assert list(watcher.poll()) == []
+
+    # Write data to the cap file
+    cap_file.write_text(
+        "Date and Time:; 11/18/2025; 08:49:54am; ; Ev [lx] (CIE1931 2°); 67.9; ; Spectral Values (380 nm - 1000 nm); 1.5; 2.5; 3.5\n",
+        encoding="utf-8",
+    )
+
+    readings = list(watcher.poll())
+    # Should yield standard metrics and a spectrum metric
+    spec_readings = [r for r in readings if r.metric == "spectrum"]
+    assert len(spec_readings) == 1
+    assert spec_readings[0].spectrum == [1.5, 2.5, 3.5]

--- a/svc/tests/test_sensor_spectrum.py
+++ b/svc/tests/test_sensor_spectrum.py
@@ -1,16 +1,14 @@
-import os
-import sqlite3
-import time
 from fastapi.testclient import TestClient
 import pytest
-from app.sensors.interface import SensorReading
 from app.sensors.jeti_spectraval_watcher import JetiSpectravalFileWatcher
 from app.state import (
-    _db_connection,
-    _ensure_sensor_db,
+    delete_sensor_readings_for_ids,
+    insert_sensor_reading,
     insert_sensor_spectrum,
     fetch_latest_spectrum,
     fetch_historical_spectrum,
+    prune_sensors_to_ids,
+    register_sensor,
 )
 from main import app
 
@@ -53,6 +51,28 @@ def test_sqlite_spectrum_operations():
     # Verify no match for far away timestamp
     hist_far = fetch_historical_spectrum("JETI-TEST", 1005.0)
     assert hist_far is None
+
+
+def test_delete_sensor_readings_for_ids_removes_spectra():
+    register_sensor("JETI-TEST", "jeti_spectraval", "JETI", None, {})
+    insert_sensor_reading("JETI-TEST", 1000.0, "lux", 1.0)
+    insert_sensor_spectrum("JETI-TEST", 1000.0, [1.0, 2.0, 3.0])
+
+    delete_sensor_readings_for_ids(["JETI-TEST"])
+
+    assert fetch_latest_spectrum("JETI-TEST") is None
+
+
+def test_prune_sensors_to_ids_removes_spectra_for_pruned_sensors():
+    register_sensor("JETI-KEEP", "jeti_spectraval", "JETI Keep", None, {})
+    register_sensor("JETI-PRUNE", "jeti_spectraval", "JETI Prune", None, {})
+    insert_sensor_spectrum("JETI-KEEP", 1000.0, [1.0, 2.0, 3.0])
+    insert_sensor_spectrum("JETI-PRUNE", 1000.0, [4.0, 5.0, 6.0])
+
+    prune_sensors_to_ids(["JETI-KEEP"])
+
+    assert fetch_latest_spectrum("JETI-KEEP") is not None
+    assert fetch_latest_spectrum("JETI-PRUNE") is None
 
 
 def test_api_spectrum_endpoints():

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -48,7 +48,6 @@
             "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
             "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
@@ -63,7 +62,6 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
             "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -161,6 +159,7 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -183,6 +182,7 @@
                     "url": "https://opencollective.com/csstools"
                 }
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -971,8 +971,7 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@types/d3-array": {
             "version": "3.2.2",
@@ -1054,6 +1053,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.28.tgz",
             "integrity": "sha512-ad4aa/RaaJS3hyGz0BGegdnSRXQBkd1CCYDCdNjBPg90UUpLgo+WlJqb9fMYUxtehmzF3PJaTWqRZjko6BRzBg==",
             "devOptional": true,
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "@types/scheduler": "*",
@@ -1065,6 +1065,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.8.tgz",
             "integrity": "sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/react": "*"
             }
@@ -1225,7 +1226,6 @@
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1235,7 +1235,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1575,7 +1574,6 @@
             "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
             "dev": true,
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1584,8 +1582,7 @@
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
@@ -1957,6 +1954,7 @@
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
             "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.1.0",
                 "data-urls": "^5.0.0",
@@ -1992,37 +1990,6 @@
                 }
             }
         },
-        "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-            "dev": true,
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "detect-libc": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 12.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/parcel"
-            },
-            "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
-            }
-        },
         "node_modules/lightningcss-android-arm64": {
             "version": "1.32.0",
             "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
@@ -2035,7 +2002,6 @@
             "os": [
                 "android"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2056,7 +2022,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2077,7 +2042,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2098,7 +2062,6 @@
             "os": [
                 "freebsd"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2119,7 +2082,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2140,7 +2102,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2161,7 +2122,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2182,7 +2142,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2203,7 +2162,6 @@
             "os": [
                 "linux"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2224,7 +2182,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2245,7 +2202,6 @@
             "os": [
                 "win32"
             ],
-            "peer": true,
             "engines": {
                 "node": ">= 12.0.0"
             },
@@ -2282,7 +2238,6 @@
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -2431,7 +2386,6 @@
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -2445,8 +2399,7 @@
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/punycode": {
             "version": "2.3.1",
@@ -2461,6 +2414,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
             "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -2472,6 +2426,7 @@
             "version": "18.2.0",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
             "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.0"
@@ -2492,6 +2447,7 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -2595,7 +2551,8 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -2872,6 +2829,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.10.tgz",
             "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",

--- a/web/src/AppHMI.tsx
+++ b/web/src/AppHMI.tsx
@@ -11,6 +11,7 @@ import { useToast } from "./utils/toast";
 import LogsPanel from "./components/LogsPanel";
 import LiveGraph from "./components/LiveGraph";
 import { type SensorInfo, type SensorReadingResponse } from "./api";
+import SpectralGraph from "./components/SpectralGraph";
 
 const METRIC_LABELS: Record<string, string> = {
     lux: "Illuminance (lx)",
@@ -178,6 +179,7 @@ export default function AppHMI() {
     const [visibleSensorIds, setVisibleSensorIds] = useState<string[]>([]);
     const sensorVisibilityUserSet = useRef(false);
     const [targetRoutineId, setTargetRoutineId] = useState<string | null>(null);
+    const [spectralModal, setSpectralModal] = useState<{ sensorId: string; fixedTs?: number } | null>(null);
 
 
     async function refresh() {
@@ -738,10 +740,20 @@ export default function AppHMI() {
                             <div className="room-section" style={{ marginTop: 20 }}>
                                 <div className="room-header">
                                     <h2 className="room-title">{`${sensor.label || sensor.id} - Latest metrics`}</h2>
-                                    <div className="room-stats">
+                                    <div className="room-stats" style={{ display: 'flex', alignItems: 'center' }}>
                                         <span>{sensorKindLabel}</span>
                                         {sensor.location && <span style={{ marginLeft: 8 }}>{sensor.location}</span>}
                                         <span style={{ marginLeft: 8 }}>{orderedMetricNames.length} metrics</span>
+                                        {sensor.kind === "jeti_spectraval" && (
+                                            <button
+                                                className="hmi-manage-btn"
+                                                onClick={() => setSpectralModal({ sensorId: sensor.id })}
+                                                style={{ marginLeft: 12, padding: "2px 8px", fontSize: "11px", height: "auto" }}
+                                                title="View real-time spectral irradiance graph"
+                                            >
+                                                View Spectrum
+                                            </button>
+                                        )}
                                     </div>
                                 </div>
                                 <div style={{ padding: "12px 16px", display: "grid", gridTemplateColumns: "1fr auto", gap: 8 }}>
@@ -848,7 +860,47 @@ export default function AppHMI() {
                     setSidePanelOpen(true);
                     setLogsPanelOpen(false);
                 }}
+                onViewSpectrum={(sensorId, ts) => {
+                    setSpectralModal({ sensorId, fixedTs: ts });
+                }}
             />
+
+            {spectralModal && (
+                <>
+                    <div className="side-panel-overlay" onClick={() => setSpectralModal(null)} style={{ zIndex: 1200 }} />
+                    <div
+                        className="logs-modal"
+                        role="dialog"
+                        aria-modal="true"
+                        style={{
+                            zIndex: 1201,
+                            maxWidth: "800px",
+                            height: "auto",
+                            minHeight: "520px",
+                        }}
+                        onClick={e => e.stopPropagation()}
+                    >
+                        <div className="logs-modal-header">
+                            <h2>
+                                Spectral Irradiance - {spectralModal.sensorId} 
+                                {spectralModal.fixedTs ? ` (${new Date(spectralModal.fixedTs * 1000).toLocaleString()})` : " (Live)"}
+                            </h2>
+                            <button
+                                className="logs-modal-close"
+                                onClick={() => setSpectralModal(null)}
+                                aria-label="Close spectrum"
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" style={{ width: "20px", height: "20px" }}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+                        <div className="logs-panel-content" style={{ padding: "20px 24px" }}>
+                            <SpectralGraph sensorId={spectralModal.sensorId} fixedTs={spectralModal.fixedTs} />
+                        </div>
+                    </div>
+                </>
+            )}
 
         </>
     );

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -184,7 +184,11 @@ export const api = {
     getLatestMetrics: () => http<SensorReadingResponse[]>("/metrics/latest"),
     getMetricHistory: (sensorId: string, metric: string, tsFrom: number, tsTo: number) =>
         http<SensorReadingResponse[]>(`/metrics/history?sensor_id=${encodeURIComponent(sensorId)}&metric=${encodeURIComponent(metric)}&ts_from=${tsFrom}&ts_to=${tsTo}`),
-    getRoutines: () => http<RoutineStatusResponse[]>("/routines")
+    getRoutines: () => http<RoutineStatusResponse[]>("/routines"),
+    getLatestSpectrum: (sensorId: string) =>
+        http<SensorSpectrumResponse>(`/sensors/${encodeURIComponent(sensorId)}/spectrum/latest`),
+    getHistoricalSpectrum: (sensorId: string, ts: number) =>
+        http<SensorSpectrumResponse>(`/sensors/${encodeURIComponent(sensorId)}/spectrum/historical?ts=${ts}`),
 };
 
 export type RoutineStatus = "idle" | "scheduled" | "running" | "error" | "done" | "stopped";
@@ -207,6 +211,14 @@ export type SensorReadingResponse = {
     metric: string;
     value: number;
     ts: number;
+};
+export type SensorSpectrumResponse = {
+    sensor_id: string;
+    ts: number;
+    wavelength_start: number;
+    wavelength_end: number;
+    wavelength_step: number;
+    values: number[];
 };
 export type SensorInfo = {
     id: string;

--- a/web/src/components/LogsPanel.tsx
+++ b/web/src/components/LogsPanel.tsx
@@ -20,6 +20,7 @@ type LogsPanelProps = {
     isMock: boolean
     sensors: SensorInfo[]
     onRoutineLinkClick?: (routineId: string) => void
+    onViewSpectrum?: (sensorId: string, ts: number) => void
 }
 
 export default function LogsPanel({
@@ -31,7 +32,8 @@ export default function LogsPanel({
     onRefresh,
     isMock,
     sensors,
-    onRoutineLinkClick
+    onRoutineLinkClick,
+    onViewSpectrum
 }: LogsPanelProps) {
     const [activeTab, setActiveTab] = useState<"audit" | "sensors" | "routines">("audit")
     const [typeFilter, setTypeFilter] = useState<"all" | "panel" | "group">("all")
@@ -695,12 +697,13 @@ export default function LogsPanel({
                                                 <span>Value</span>
                                                 <span className="logs-sort-indicator">{sensorSortIndicator("value")}</span>
                                             </th>
+                                            <th>Actions</th>
                                         </tr>
                                     </thead>
                                     <tbody>
                                         {sensorLogs.length === 0 ? (
                                             <tr>
-                                                <td colSpan={5} className="logs-empty">
+                                                <td colSpan={6} className="logs-empty">
                                                     {sensorLoading
                                                         ? "Loading sensor logs..."
                                                         : "No sensor readings match the current filters"}
@@ -714,6 +717,32 @@ export default function LogsPanel({
                                                     <td>{row.sensor_kind || "-"}</td>
                                                     <td>{row.metric}</td>
                                                     <td>{row.value.toFixed(4)}</td>
+                                                    <td>
+                                                        {row.sensor_kind === "jeti_spectraval" && onViewSpectrum && (
+                                                            <button
+                                                                className="hmi-link-btn"
+                                                                onClick={() => onViewSpectrum(row.sensor_id, row.ts)}
+                                                                title="View Spectrogram at this timestamp"
+                                                                style={{
+                                                                    background: 'none',
+                                                                    border: 'none',
+                                                                    color: 'var(--hmi-accent)',
+                                                                    textDecoration: 'underline',
+                                                                    cursor: 'pointer',
+                                                                    padding: 0,
+                                                                    font: 'inherit',
+                                                                    display: 'inline-flex',
+                                                                    alignItems: 'center',
+                                                                    gap: '4px'
+                                                                }}
+                                                            >
+                                                                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: "16px", height: "16px" }}>
+                                                                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+                                                                </svg>
+                                                                <span>Spectrogram</span>
+                                                            </button>
+                                                        )}
+                                                    </td>
                                                 </tr>
                                             ))
                                         )}

--- a/web/src/components/SpectralGraph.tsx
+++ b/web/src/components/SpectralGraph.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react";
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { api, type SensorSpectrumResponse } from "../api";
+
+interface SpectralGraphProps {
+    sensorId: string;
+    fixedTs?: number;
+    height?: number;
+}
+
+export default function SpectralGraph({ sensorId, fixedTs, height = 350 }: SpectralGraphProps) {
+    const [data, setData] = useState<SensorSpectrumResponse | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadData = async () => {
+        try {
+            let res: SensorSpectrumResponse;
+            if (fixedTs != null) {
+                res = await api.getHistoricalSpectrum(sensorId, fixedTs);
+            } else {
+                res = await api.getLatestSpectrum(sensorId);
+            }
+            setData(res);
+            setError(null);
+        } catch (err: any) {
+            console.error("Failed to load spectral data", err);
+            setError(err.message || String(err));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        setLoading(true);
+        loadData();
+
+        if (fixedTs == null) {
+            const interval = setInterval(loadData, 5000); // Poll every 5s for live data
+            return () => clearInterval(interval);
+        }
+    }, [sensorId, fixedTs]);
+
+    if (loading && !data) {
+        return (
+            <div style={{ height, display: "flex", alignItems: "center", justifyContent: "center", color: "var(--hmi-text-muted)" }}>
+                Loading spectral data...
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div style={{ height, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", color: "var(--hmi-danger)", padding: 20, textAlign: "center" }}>
+                <div style={{ fontWeight: "bold", marginBottom: 8 }}>Failed to load spectrum</div>
+                <div style={{ fontSize: "13px", opacity: 0.8 }}>{error}</div>
+            </div>
+        );
+    }
+
+    if (!data || !data.values || !data.values.length) {
+        return (
+            <div style={{ height, display: "flex", alignItems: "center", justifyContent: "center", color: "var(--hmi-text-muted)" }}>
+                No spectral data available
+            </div>
+        );
+    }
+
+    const step = data.wavelength_step || 1;
+    const chartData = data.values.map((val, idx) => ({
+        wavelength: data.wavelength_start + idx * step,
+        irradiance: val,
+    }));
+
+    const formatValue = (value: number) => {
+        if (value === 0) return "0";
+        if (Math.abs(value) < 0.001) {
+            return value.toExponential(2);
+        }
+        return value.toFixed(5);
+    };
+
+    return (
+        <div style={{ height, padding: "10px 10px 10px 0" }}>
+            <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={chartData} margin={{ top: 10, right: 10, left: 90, bottom: 40 }}>
+                    <defs>
+                        <linearGradient id="spectralGradient" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0%" stopColor="#4b0082" />
+                            <stop offset="15%" stopColor="#0000ff" />
+                            <stop offset="27.5%" stopColor="#00ffff" />
+                            <stop offset="47.5%" stopColor="#00ff00" />
+                            <stop offset="52.5%" stopColor="#ffff00" />
+                            <stop offset="60%" stopColor="#ff7f00" />
+                            <stop offset="70%" stopColor="#ff0000" />
+                            <stop offset="100%" stopColor="#800000" />
+                        </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--hmi-border)" />
+                    <XAxis
+                        dataKey="wavelength"
+                        stroke="var(--hmi-text-muted)"
+                        tick={{ fill: 'var(--hmi-text-muted)' }}
+                        label={{
+                            value: 'Wavelength (nm)',
+                            position: 'bottom',
+                            offset: 20,
+                            fill: 'var(--hmi-text-muted)',
+                            style: { fontSize: '13px' }
+                        }}
+                    />
+                    <YAxis
+                        stroke="var(--hmi-text-muted)"
+                        tick={{ fill: 'var(--hmi-text-muted)' }}
+                        tickFormatter={formatValue}
+                        label={{
+                            value: 'Spectral Irradiance',
+                            angle: -90,
+                            position: 'left',
+                            offset: 65,
+                            fill: 'var(--hmi-text-muted)',
+                            style: { fontSize: '13px', textAnchor: 'middle' }
+                        }}
+                    />
+                    <Tooltip
+                        contentStyle={{
+                            backgroundColor: 'var(--hmi-surface)',
+                            border: '1px solid var(--hmi-border)',
+                            borderRadius: 4,
+                            color: 'var(--hmi-text)'
+                        }}
+                        labelFormatter={(label) => `Wavelength: ${label} nm`}
+                        formatter={(value: any) => [formatValue(Number(value)), "Irradiance"]}
+                    />
+                    <Area
+                        type="monotone"
+                        dataKey="irradiance"
+                        stroke="#ffffff"
+                        strokeWidth={1.5}
+                        fillOpacity={0.7}
+                        fill="url(#spectralGradient)"
+                        animationDuration={500}
+                    />
+                </AreaChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
This PR implements a database-backed Spectral Irradiance Graph for the JETI Spectraval sensor in the Glazing Control HMI. It enables users to view a point-in-time spectrum snapshot (380–780nm) either live in real-time (polled every 5 seconds) under the Sensors tab, or historically for any past log entry from the Sensor Logs table.

## Type
- [x] Feature
- [ ] Fix
- [x] Docs
- [ ] Chore

## Testing
Ran automated tests, as well as tested manually.

## Risk and rollout
Doesnt modify any core behavior, so shouldnt have any side effects.

## Checklist
- [ ] Issue linked if applicable
- [ ] Added or updated docs
- [x] CI green
- [ ] At least one reviewer not the author
