### PR TITLE
Add serial COM auto-detection for sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,4 @@ svc/data/jeti_sim_output/
 
 # Local temporary research repo / scratch workspace
 /.tmp_luox/
+*.cap

--- a/DEV-SETUP.md
+++ b/DEV-SETUP.md
@@ -104,6 +104,8 @@ uv run python main.py
 
 For the EKO C-BOX, set `eko_ms90_plus[].host` to the C-BOX IP address, usually `192.168.2.20`, and `eko_ms90_plus[].port` to TCP port `502`. The app no longer uses a USB-to-RS485 adapter or COM port for EKO.
 
+For T-10A and JETI direct serial configs, set `port` to `"auto"` or omit it so the backend probes available COM ports at startup. Use `port_match` metadata such as `serial_number`, `description`, `hwid`, `vid`, or `pid` when multiple identical USB serial devices must be pinned to specific logical sensor configs.
+
 ---
 
 ## Using pip and venv (Legacy)

--- a/docs/on_site_sensor_checklist.md
+++ b/docs/on_site_sensor_checklist.md
@@ -17,21 +17,21 @@ Use this at the trailer/lab PC after the hardware is physically installed.
 ## Windows Checks
 
 1. Open Device Manager.
-2. Record the COM port for each `T-10A` body.
-3. Record the COM port for each JETI device that will use direct serial mode.
+2. Confirm a COM port appears for each `T-10A` body.
+3. Confirm a COM port appears for each JETI device that will use direct serial mode.
 4. If a JETI device is missing, install the JETI USB driver and reconnect it.
 5. Open the C-BOX web UI from the site computer, usually `http://192.168.2.20/`.
 6. In the C-BOX web UI, open `Modbus -> Setup` and confirm Modbus TCP access is enabled.
 
 ## Update `svc/data/sensors_config.json`
 
-1. Set `t10a[].port` to the actual T-10A COM port.
+1. Set `t10a[].port` to `"auto"` or omit it so the backend detects the T-10A COM port.
 2. Set `t10a[].heads[].head_no` to the actual physical T-10A adaptor/head ID.
 3. Set `jeti_spectraval[].transport` to either `file` or `serial_scpi`.
 4. If JETI uses file mode, set `jeti_spectraval[].output_path` to the actual live `.cap` file.
    **REQUIREMENT**: When configuring multiple JETI sensors (Spectraval or Specbos) in file mode, you MUST configure the Jeti software to export each sensor's data to a distinct file name (e.g., `spectraval_1.cap`, `specbos.cap`). Do not point multiple sensors to the same file, as this will cause data collisions.
-5. If JETI uses serial mode, set `jeti_spectraval[].port` to the JETI COM port.
-6. If JETI uses serial mode, set `jeti_spectraval[].baudrate`:
+5. If JETI uses serial mode, set `jeti_spectraval[].port` to `"auto"` or omit it so the backend detects the JETI COM port.
+6. If JETI uses serial mode, set `jeti_spectraval[].baudrate` or set it to `"auto"`:
    - `921600` for `spectraval 1511`
    - `115200` for `specbos 1211-2`
 7. Set `eko_ms90_plus[].host` to the C-BOX IP address, usually `192.168.2.20`.
@@ -74,7 +74,7 @@ For the full step-by-step connection instructions for each sensor and each suppo
 ## If Something Fails
 
 - No T-10A data:
-  - re-check USB COM port
+  - confirm the USB COM port appears in Device Manager
   - verify head IDs
   - verify straight CAT5 and external power for multi-point mode
   - stop the backend, then probe the port directly (9600 7E1, not 8N1):
@@ -88,7 +88,7 @@ uv run python scripts/read_t10a_serial.py COM5
 - No JETI data:
   - re-check driver install
   - confirm the PC measurement software is writing to the configured `output_path`, or
-  - confirm COM port and baudrate for serial mode
+  - confirm a COM port appears and the baudrate is correct for serial mode
 - No EKO data:
   - open the C-BOX web UI from the site computer and confirm it is reachable
   - confirm `Modbus -> Setup` has Modbus TCP access enabled

--- a/docs/real_sensor_setup.md
+++ b/docs/real_sensor_setup.md
@@ -89,9 +89,9 @@ The app supports one practical connection path for `T-10A`: head chain to T-10A 
 3. If any CAT5 segment is used in the chain, use straight CAT5/10Base-T patch cable only.
 4. Connect the T-10A body to the PC by USB.
 5. Power on the T-10A body and confirm it is detected by Windows.
-6. Open Device Manager and record the assigned COM port under `Ports (COM & LPT)`.
+6. Confirm a COM port appears under `Ports (COM & LPT)`.
 7. Update `svc/data/sensors_config.json`:
-   - set `t10a[].port` to the actual COM port
+   - set `t10a[].port` to `"auto"` or omit it to let the backend detect the T-10A COM port at startup
    - set `heads[].head_no` to the physical head/adaptor ID
    - keep `heads[].sensor_id` and `heads[].label` aligned with the physical head location
 8. Start the backend and confirm the T-10A sensor reports `lux`.
@@ -104,9 +104,9 @@ The app supports one practical connection path for `T-10A`: head chain to T-10A 
 4. Connect the `AC-A412` external power supply for the multi-head setup.
 5. Assign a unique physical ID to each head/adaptor. The supported range is `00` through `29`.
 6. Connect the T-10A body to the PC by USB.
-7. Open Device Manager and record the COM port for that T-10A body.
+7. Confirm a COM port appears for that T-10A body.
 8. Update `svc/data/sensors_config.json`:
-   - set the device `port`
+   - set the device `port` to `"auto"` or omit it to let the backend detect the T-10A COM port at startup
    - set each `heads[].head_no` to the actual physical ID
    - keep each `sensor_id` and `label` tied to the installed head location
 9. Start the backend and verify every configured T-10A head appears in `GET /sensors`.
@@ -117,7 +117,8 @@ The app supports one practical connection path for `T-10A`: head chain to T-10A 
 - Do not use crossover Ethernet cables.
 - Multi-head mode needs external power.
 - If `head_no` does not match the physical head/adaptor ID, the service will poll the wrong head or no head.
-- USB COM assignments can change if you move the USB cable to a different PC port.
+- USB COM assignments can change if you move the USB cable to a different PC port. Use `"port": "auto"` for T-10A configs so the backend probes the available COM ports using the T-10A protocol.
+- If multiple identical T-10A bodies are connected, `"auto"` assigns them by detected COM-port order. Add `port_match` hints such as `serial_number`, `description`, `hwid`, `vid`, or `pid` if the USB adapter metadata is available and a specific logical sensor must always bind to the same physical body.
 
 ## 5) JETI Setup
 
@@ -148,15 +149,15 @@ Use this when you want the backend to talk to the JETI device directly instead o
 
 1. Install the JETI USB driver on the local PC if needed.
 2. Connect the JETI device to the PC by USB.
-3. Open Device Manager and find the JETI virtual COM port under `Ports (COM & LPT)`.
-4. Record the COM port.
+3. Confirm the JETI virtual COM port appears under `Ports (COM & LPT)`.
+4. Leave the COM port on auto-detect unless you need to pin it.
 5. Decide which device model is connected:
    - `spectraval 1511` typically uses `921600`
    - `specbos 1211-2` typically uses `115200`
 6. Update `svc/data/sensors_config.json`:
    - set `jeti_spectraval[].transport` to `"serial_scpi"`
-   - set `jeti_spectraval[].port` to the JETI COM port
-   - set `jeti_spectraval[].baudrate` to the correct device baud rate
+   - set `jeti_spectraval[].port` to `"auto"` or omit it to let the backend detect the JETI COM port at startup
+   - set `jeti_spectraval[].baudrate` to the correct device baud rate, or set it to `"auto"` with optional `baudrate_candidates`
    - set `tint_ms` and `avg_count` if the measurement timing needs adjustment
 7. Start the backend in real mode.
 8. Confirm the JETI sensor appears in `GET /sensors`.
@@ -167,7 +168,7 @@ Use this when you want the backend to talk to the JETI device directly instead o
 - The schematic confirms USB to the PC. The file-vs-serial choice is a software integration choice, not a different physical cable path.
 - File mode only works if the configured `output_path` exactly matches the real file or folder on the PC.
 - The backend can now recover if the watched `.cap` file or folder appears after startup, but the path still has to be correct.
-- Direct serial mode requires the correct COM port and baudrate before anything else will work.
+- Direct serial mode can auto-detect the COM port by sending SPECFIRM `*IDN?` / `*VERS?` probes. If more than one JETI device is attached, use `port_match` metadata hints to keep each logical sensor tied to the intended instrument.
 - The backend now parses SPECFIRM format `2` correctly as `wavelength<TAB>value` pairs.
 
 ## 6) EKO MS-90+ / C-BOX Setup

--- a/svc/README.md
+++ b/svc/README.md
@@ -121,6 +121,20 @@ The backend supports three real sensor paths via `svc/data/sensors_config.json`:
   - `transport: "serial_scpi"` (direct SPECFIRM serial)
 - `eko_ms90_plus`: EKO C-BOX over Ethernet Modbus TCP. The app does not use USB-to-RS485 for EKO anymore.
 
+For USB serial sensors, set `port` to `"auto"` or omit it to let startup scan available COM ports. T-10A probing uses the Konica Minolta 7E1 command protocol; JETI serial probing uses SPECFIRM `*IDN?` / `*VERS?`. If several identical devices are attached, add optional `port_match` metadata so each logical sensor binds to the intended physical USB adapter:
+
+```json
+{
+  "port": "auto",
+  "port_match": {
+    "serial_number": "JETI-ABC123",
+    "description": "USB Serial"
+  }
+}
+```
+
+JETI serial configs may also set `"baudrate": "auto"` and optionally `baudrate_candidates`, for example `[115200, 921600]`.
+
 EKO TCP config example:
 
 ```json

--- a/svc/app/sensors/jeti_specfirm_client.py
+++ b/svc/app/sensors/jeti_specfirm_client.py
@@ -46,6 +46,8 @@ class JetiSpecfirmClient(SensorClient):
         self._sensor_id = sensor_id
         self._label = label
         self._location = location
+        self._port = port
+        self._baudrate = int(baudrate)
         self._tint_ms = float(tint_ms)
         self._avg_count = int(avg_count)
         self._w_start = int(wavelength_start_nm)
@@ -60,7 +62,7 @@ class JetiSpecfirmClient(SensorClient):
 
         self.ser = serial.Serial(
             port=port,
-            baudrate=baudrate,
+            baudrate=self._baudrate,
             bytesize=serial.EIGHTBITS,
             parity=serial.PARITY_NONE,
             stopbits=serial.STOPBITS_ONE,
@@ -70,13 +72,14 @@ class JetiSpecfirmClient(SensorClient):
             "JetiSpecfirmClient[%s] opened %s (baud=%s, tint_ms=%s, avg=%s)",
             self.id,
             port,
-            baudrate,
+            self._baudrate,
             self._tint_ms,
             self._avg_count,
         )
 
-    def _read_until_idle(
-        self,
+    @staticmethod
+    def _read_until_idle_from_serial(
+        ser,
         *,
         total_timeout_s: float = 4.0,
         idle_timeout_s: float = 0.10,
@@ -86,7 +89,7 @@ class JetiSpecfirmClient(SensorClient):
         buf = bytearray()
 
         while time.monotonic() < deadline:
-            chunk = self.ser.read(4096)
+            chunk = ser.read(4096)
             if chunk:
                 buf.extend(chunk)
                 last_rx = time.monotonic()
@@ -95,6 +98,18 @@ class JetiSpecfirmClient(SensorClient):
             if buf and (time.monotonic() - last_rx) >= idle_timeout_s:
                 break
         return bytes(buf)
+
+    def _read_until_idle(
+        self,
+        *,
+        total_timeout_s: float = 4.0,
+        idle_timeout_s: float = 0.10,
+    ) -> bytes:
+        return self._read_until_idle_from_serial(
+            self.ser,
+            total_timeout_s=total_timeout_s,
+            idle_timeout_s=idle_timeout_s,
+        )
 
     def _send(self, command: str, *, timeout_s: float = 4.0) -> bytes:
         payload = command.encode("ascii") + b"\r"
@@ -115,6 +130,47 @@ class JetiSpecfirmClient(SensorClient):
             .replace(b"\x03", b" ")
             .decode("latin-1", errors="ignore")
         )
+
+    @classmethod
+    def probe_port(
+        cls,
+        *,
+        port: str,
+        baudrate: int = 921600,
+        timeout_s: float = 1.0,
+    ) -> bool:
+        ser = None
+        try:
+            ser = serial.Serial(
+                port=port,
+                baudrate=baudrate,
+                bytesize=serial.EIGHTBITS,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=timeout_s,
+            )
+            for command in ("*IDN?", "*VERS?"):
+                ser.reset_input_buffer()
+                ser.write(command.encode("ascii") + b"\r")
+                ser.flush()
+                raw = cls._read_until_idle_from_serial(
+                    ser,
+                    total_timeout_s=timeout_s,
+                    idle_timeout_s=0.05,
+                )
+                text = cls._clean_text(raw).upper()
+                if any(token in text for token in ("JETI", "SPECFIRM", "SPECTRAVAL", "SPECBOS")):
+                    return True
+            return False
+        except Exception as e:
+            logger.debug("JETI probe failed on %s at %s baud: %s", port, baudrate, e)
+            return False
+        finally:
+            if ser is not None:
+                try:
+                    ser.close()
+                except Exception:
+                    pass
 
     def _extract_floats(self, raw: bytes) -> list[float]:
         # Remove common control bytes (ACK, BEL, NAK) before tokenizing.

--- a/svc/app/sensors/manager.py
+++ b/svc/app/sensors/manager.py
@@ -22,6 +22,12 @@ from .interface import SensorClient, SensorReading
 from .jeti_specfirm_client import JetiSpecfirmClient
 from .jeti_spectraval_sim import JetiSpectravalSimClient
 from .jeti_spectraval_watcher import JetiSpectravalFileWatcher
+from .serial_autodetect import (
+    find_serial_port,
+    is_auto_port,
+    serial_match_config,
+    serial_port_key,
+)
 from .t10a_client import T10AClient, T10AHeadConfig
 from .t10a_sim_client import T10ASimClient
 
@@ -57,7 +63,7 @@ def _get_sensors_config_file() -> str:
 
 def _default_jeti_baudrate(dev_cfg: dict) -> int:
     explicit_baudrate = dev_cfg.get("baudrate")
-    if explicit_baudrate not in (None, ""):
+    if explicit_baudrate not in (None, "") and not is_auto_port(explicit_baudrate):
         return int(explicit_baudrate)
 
     fingerprint = " ".join(
@@ -71,6 +77,46 @@ def _default_jeti_baudrate(dev_cfg: dict) -> int:
 
 def _env_flag(name: str, default: str = "false") -> bool:
     return os.getenv(name, default).lower() in {"1", "true", "yes", "on"}
+
+
+def _t10a_baudrate(dev_cfg: dict) -> int:
+    raw_baudrate = dev_cfg.get("baudrate")
+    if raw_baudrate in (None, "") or is_auto_port(raw_baudrate):
+        return 9600
+    return int(raw_baudrate)
+
+
+def _parse_int_candidates(value) -> list[int]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, (list, tuple, set)):
+        raw_values = list(value)
+    else:
+        raw_values = [part.strip() for part in str(value).split(",")]
+
+    candidates: list[int] = []
+    for raw_value in raw_values:
+        if raw_value in (None, ""):
+            continue
+        candidate = int(raw_value)
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return candidates
+
+
+def _jeti_baudrate_candidates(dev_cfg: dict) -> list[int]:
+    explicit_baudrate = dev_cfg.get("baudrate")
+    if explicit_baudrate not in (None, "") and not is_auto_port(explicit_baudrate):
+        return [int(explicit_baudrate)]
+
+    configured = dev_cfg.get("baudrate_candidates", dev_cfg.get("autodetect_baudrates"))
+    candidates = _parse_int_candidates(configured)
+    if candidates:
+        return candidates
+
+    inferred = _default_jeti_baudrate(dev_cfg)
+    candidates = [inferred, 921600, 115200, 230400, 38400, 3000000]
+    return list(dict.fromkeys(candidates))
 
 
 def _load_config() -> dict:
@@ -96,6 +142,7 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
     cfg = _load_config()
     clients_with_interval: list[tuple[SensorClient, float]] = []
     configured_sensor_ids: set[str] = set()
+    reserved_serial_ports: set[str] = set()
 
     is_sim_mode = MODE == "sim"
     is_real_mode = MODE == "real"
@@ -115,17 +162,11 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
 
     for dev_cfg in t10a_configs:
         device_id = dev_cfg["device_id"]
-        port = str(dev_cfg.get("port") or "")
+        raw_port = dev_cfg.get("port")
+        port = str(raw_port or "").strip()
         interval_s = float(dev_cfg.get("interval_s", 60.0))
         timeout_s = float(dev_cfg.get("timeout_s", 1.0))
         protocol_cfg = dev_cfg.get("protocol", {})
-
-        if use_real_t10a and (not port or port == "SIM"):
-            logger.warning(
-                "Skip T10A device %s: missing 'port'; real mode requires a USB COM port",
-                device_id,
-            )
-            continue
 
         heads_cfg: list[T10AHeadConfig] = []
         for h in dev_cfg.get("heads", []):
@@ -137,6 +178,47 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
             )
             heads_cfg.append(hc)
 
+        if not heads_cfg:
+            continue
+
+        if use_real_t10a:
+            if port.upper() == "SIM":
+                logger.warning(
+                    "Skip T10A device %s: port='SIM' cannot be used for real serial polling",
+                    device_id,
+                )
+                continue
+
+            if is_auto_port(raw_port):
+                probe_head_no = heads_cfg[0].head_no
+                autodetect_timeout_s = float(dev_cfg.get("autodetect_timeout_s", timeout_s))
+                port = find_serial_port(
+                    sensor_name=f"T10A device {device_id}",
+                    requested_port=raw_port,
+                    reserved_ports=reserved_serial_ports,
+                    match=serial_match_config(dev_cfg),
+                    probe=lambda candidate_port, probe_head_no=probe_head_no: T10AClient.probe_port(
+                        port=candidate_port,
+                        timeout_s=autodetect_timeout_s,
+                        protocol=protocol_cfg,
+                        baudrate=_t10a_baudrate(dev_cfg),
+                        head_no=probe_head_no,
+                    ),
+                ) or ""
+                if not port:
+                    logger.warning(
+                        "Skip T10A device %s: could not auto-detect a matching USB COM port",
+                        device_id,
+                    )
+                    continue
+
+            port_key = serial_port_key(port)
+            if port_key in reserved_serial_ports:
+                logger.warning("Skip T10A device %s: serial port %s is already in use", device_id, port)
+                continue
+            reserved_serial_ports.add(port_key)
+
+        for hc in heads_cfg:
             register_sensor(
                 sensor_id=hc.sensor_id,
                 kind="t10a",
@@ -152,9 +234,6 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
             )
             configured_sensor_ids.add(hc.sensor_id)
 
-        if not heads_cfg:
-            continue
-
         if use_real_t10a:
             try:
                 client = T10AClient(
@@ -163,7 +242,7 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
                     heads=heads_cfg,
                     timeout_s=timeout_s,
                     protocol=protocol_cfg,
-                    baudrate=int(dev_cfg.get("baudrate", 9600)),
+                    baudrate=_t10a_baudrate(dev_cfg),
                 )
                 clients_with_interval.append((client, interval_s))
             except Exception as e:
@@ -206,18 +285,78 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
                 )
                 continue
 
-            port = dev_cfg.get("port")
-            if not port:
-                logger.warning("Skip JETI serial_scpi %s: missing 'port'", sensor_id)
-                continue
-
-            baudrate = _default_jeti_baudrate(dev_cfg)
+            raw_port = dev_cfg.get("port")
+            port = str(raw_port or "").strip()
+            baudrate_candidates = _jeti_baudrate_candidates(dev_cfg)
+            baudrate = baudrate_candidates[0]
             timeout_s = float(dev_cfg.get("timeout_s", 1.0))
+            autodetect_timeout_s = float(dev_cfg.get("autodetect_timeout_s", timeout_s))
             tint_ms = float(dev_cfg.get("tint_ms", 100.0))
             avg_count = int(dev_cfg.get("avg_count", 1))
             w_start = int(dev_cfg.get("wavelength_start_nm", 380))
             w_end = int(dev_cfg.get("wavelength_end_nm", 780))
             w_step = int(dev_cfg.get("wavelength_step_nm", 1))
+
+            if port.upper() == "SIM":
+                logger.warning(
+                    "Skip JETI serial_scpi %s: port='SIM' cannot be used for real serial polling",
+                    sensor_id,
+                )
+                continue
+
+            if is_auto_port(raw_port):
+                selected_baudrate = baudrate
+
+                def probe_jeti(candidate_port: str) -> bool:
+                    nonlocal selected_baudrate
+                    for candidate_baudrate in baudrate_candidates:
+                        if JetiSpecfirmClient.probe_port(
+                            port=candidate_port,
+                            baudrate=candidate_baudrate,
+                            timeout_s=autodetect_timeout_s,
+                        ):
+                            selected_baudrate = candidate_baudrate
+                            return True
+                    return False
+
+                port = find_serial_port(
+                    sensor_name=f"JETI serial_scpi {sensor_id}",
+                    requested_port=raw_port,
+                    reserved_ports=reserved_serial_ports,
+                    match=serial_match_config(dev_cfg),
+                    probe=probe_jeti,
+                ) or ""
+                if not port:
+                    logger.warning(
+                        "Skip JETI serial_scpi %s: could not auto-detect a matching USB COM port",
+                        sensor_id,
+                    )
+                    continue
+                baudrate = selected_baudrate
+            elif "baudrate" in dev_cfg and is_auto_port(dev_cfg.get("baudrate")):
+                detected_baudrate = None
+                for candidate_baudrate in baudrate_candidates:
+                    if JetiSpecfirmClient.probe_port(
+                        port=port,
+                        baudrate=candidate_baudrate,
+                        timeout_s=autodetect_timeout_s,
+                    ):
+                        detected_baudrate = candidate_baudrate
+                        break
+                if detected_baudrate is None:
+                    logger.warning(
+                        "Skip JETI serial_scpi %s: could not auto-detect baudrate on %s",
+                        sensor_id,
+                        port,
+                    )
+                    continue
+                baudrate = detected_baudrate
+
+            port_key = serial_port_key(port)
+            if port_key in reserved_serial_ports:
+                logger.warning("Skip JETI serial_scpi %s: serial port %s is already in use", sensor_id, port)
+                continue
+            reserved_serial_ports.add(port_key)
 
             try:
                 register_sensor(

--- a/svc/app/sensors/serial_autodetect.py
+++ b/svc/app/sensors/serial_autodetect.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from serial.tools import list_ports
+
+logger = logging.getLogger(__name__)
+
+AUTO_PORT_VALUES = {"", "auto", "autodetect", "detect", "*"}
+
+
+@dataclass(frozen=True)
+class SerialPortCandidate:
+    device: str
+    name: str
+    description: str
+    hwid: str
+    manufacturer: str
+    product: str
+    serial_number: str
+    location: str
+    vid: int | None
+    pid: int | None
+
+
+def is_auto_port(value: Any) -> bool:
+    if value is None:
+        return True
+    return str(value).strip().lower() in AUTO_PORT_VALUES
+
+
+def serial_port_key(port: str) -> str:
+    return str(port).strip().casefold()
+
+
+def _port_sort_key(port: str) -> tuple[str, int, str]:
+    match = re.fullmatch(r"COM(\d+)", str(port).strip(), flags=re.IGNORECASE)
+    if match:
+        return ("com", int(match.group(1)), str(port).casefold())
+    return ("other", 0, str(port).casefold())
+
+
+def _candidate_from_port_info(info: Any) -> SerialPortCandidate:
+    return SerialPortCandidate(
+        device=str(getattr(info, "device", "") or ""),
+        name=str(getattr(info, "name", "") or ""),
+        description=str(getattr(info, "description", "") or ""),
+        hwid=str(getattr(info, "hwid", "") or ""),
+        manufacturer=str(getattr(info, "manufacturer", "") or ""),
+        product=str(getattr(info, "product", "") or ""),
+        serial_number=str(getattr(info, "serial_number", "") or ""),
+        location=str(getattr(info, "location", "") or ""),
+        vid=getattr(info, "vid", None),
+        pid=getattr(info, "pid", None),
+    )
+
+
+def serial_match_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """
+    Pull optional USB/port match hints out of a sensor config.
+
+    String values are treated as case-insensitive containment checks against
+    pyserial's port metadata. vid/pid may be decimal integers or hex strings.
+    """
+    match: dict[str, Any] = {}
+    for key in ("serial_match", "port_match"):
+        section = config.get(key)
+        if isinstance(section, Mapping):
+            match.update(section)
+
+    aliases = {
+        "serial_number": "serial_number",
+        "usb_serial_number": "serial_number",
+        "vid": "vid",
+        "usb_vid": "vid",
+        "pid": "pid",
+        "usb_pid": "pid",
+        "manufacturer": "manufacturer",
+        "product": "product",
+        "description": "description",
+        "hwid": "hwid",
+        "location": "location",
+        "device": "device",
+        "name": "name",
+    }
+    for source_key, target_key in aliases.items():
+        if source_key in config and target_key not in match:
+            match[target_key] = config[source_key]
+
+    return {key: value for key, value in match.items() if value not in (None, "")}
+
+
+def list_serial_port_candidates(
+    *,
+    reserved_ports: set[str] | None = None,
+    match: Mapping[str, Any] | None = None,
+) -> list[SerialPortCandidate]:
+    reserved = {serial_port_key(port) for port in reserved_ports or set()}
+    candidates = [
+        _candidate_from_port_info(info)
+        for info in list_ports.comports()
+        if str(getattr(info, "device", "") or "").strip()
+    ]
+    candidates = [
+        candidate
+        for candidate in candidates
+        if serial_port_key(candidate.device) not in reserved
+        and _matches_candidate(candidate, match or {})
+    ]
+    return sorted(candidates, key=lambda candidate: _port_sort_key(candidate.device))
+
+
+def find_serial_port(
+    *,
+    sensor_name: str,
+    requested_port: Any,
+    probe: Callable[[str], bool],
+    reserved_ports: set[str] | None = None,
+    match: Mapping[str, Any] | None = None,
+) -> str | None:
+    if not is_auto_port(requested_port):
+        return str(requested_port).strip()
+
+    candidates = list_serial_port_candidates(
+        reserved_ports=reserved_ports,
+        match=match,
+    )
+    if not candidates:
+        logger.warning("Auto-detect %s: no candidate serial ports found", sensor_name)
+        return None
+
+    scanned: list[str] = []
+    for candidate in candidates:
+        scanned.append(candidate.device)
+        try:
+            if probe(candidate.device):
+                logger.info(
+                    "Auto-detected %s on %s (%s)",
+                    sensor_name,
+                    candidate.device,
+                    candidate.description or candidate.hwid or "serial port",
+                )
+                return candidate.device
+        except Exception as e:
+            logger.debug(
+                "Auto-detect %s: probe failed on %s: %s",
+                sensor_name,
+                candidate.device,
+                e,
+            )
+
+    logger.warning(
+        "Auto-detect %s: no matching device found after scanning %s",
+        sensor_name,
+        ", ".join(scanned),
+    )
+    return None
+
+
+def _matches_candidate(
+    candidate: SerialPortCandidate,
+    match: Mapping[str, Any],
+) -> bool:
+    for key, expected in match.items():
+        if expected in (None, ""):
+            continue
+        if key in {"vid", "pid"}:
+            actual = getattr(candidate, key)
+            try:
+                expected_values = _expected_int_values(expected)
+            except ValueError as e:
+                logger.warning("Ignoring invalid serial port %s match %r: %s", key, expected, e)
+                return False
+            if actual is None or actual not in expected_values:
+                return False
+            continue
+
+        if not hasattr(candidate, key):
+            logger.warning("Ignoring unknown serial port match key %r", key)
+            continue
+
+        actual_text = str(getattr(candidate, key) or "").casefold()
+        if not any(str(value).casefold() in actual_text for value in _expected_values(expected)):
+            return False
+
+    return True
+
+
+def _expected_values(expected: Any) -> list[Any]:
+    if isinstance(expected, (list, tuple, set)):
+        return list(expected)
+    return [expected]
+
+
+def _expected_int_values(expected: Any) -> set[int]:
+    values: set[int] = set()
+    for value in _expected_values(expected):
+        if isinstance(value, int):
+            values.add(value)
+            continue
+        text = str(value).strip()
+        base = 16 if text.lower().startswith("0x") else 10
+        values.add(int(text, base))
+    return values

--- a/svc/app/sensors/t10a_client.py
+++ b/svc/app/sensors/t10a_client.py
@@ -78,7 +78,7 @@ class T10AClient(SensorClient):
 
         self.ser = serial.Serial(
             port=self.port,
-            baudrate=int(protocol_cfg.get("baudrate", baudrate)),
+            baudrate=self._coerce_baudrate(protocol_cfg.get("baudrate"), baudrate),
             bytesize=serial.SEVENBITS,
             parity=serial.PARITY_EVEN,
             stopbits=serial.STOPBITS_ONE,
@@ -110,6 +110,12 @@ class T10AClient(SensorClient):
             bcc_val ^= b
         return f"{bcc_val:02X}".encode("ascii")
 
+    @staticmethod
+    def _coerce_baudrate(value, default: int = 9600) -> int:
+        if value in (None, "") or str(value).strip().lower() == "auto":
+            return int(default)
+        return int(value)
+
     def _build_frame(self, head_no: int, cmd: str, params: str = "") -> bytes:
         """
         Build a T-10A frame for given head + command.
@@ -133,20 +139,48 @@ class T10AClient(SensorClient):
         bcc = self._compute_bcc(body_with_etx)
         return b"\x02" + body_with_etx + bcc + b"\r\n"
 
+    @classmethod
+    def _build_probe_frame(
+        cls,
+        *,
+        head_no: int,
+        cmd: str,
+        params: str,
+        protocol: dict | None = None,
+    ) -> bytes:
+        protocol_cfg = protocol or {}
+        head_index_base = int(protocol_cfg.get("head_index_base", 0))
+        body_template = str(protocol_cfg.get("body_template", "{head:02d}{cmd}{params}"))
+        head_address = head_no + head_index_base
+        body = body_template.format(
+            head=head_address,
+            head_no=head_no,
+            cmd=cmd,
+            params=params,
+        )
+
+        body_with_etx = body.encode("ascii") + b"\x03"
+        bcc = cls._compute_bcc(body_with_etx)
+        return b"\x02" + body_with_etx + bcc + b"\r\n"
+
     def _response_length_for(self, cmd: str) -> int:
         if cmd == self._measure_command:
             return self._long_reply_len
         return self._short_reply_len
 
+    @staticmethod
+    def _read_serial_reply(ser, expected_len: int) -> bytes:
+        data = ser.read(expected_len)
+        if len(data) < expected_len:
+            # Fallback for adapters that chunk differently.
+            extra = ser.read_until(expected=b"\r\n", size=max(expected_len, 64))
+            if extra and not data.endswith(extra):
+                data = (data + extra)[: max(expected_len, len(data + extra))]
+        return data
+
     def _read_reply(self, cmd: str) -> str:
         """Read a fixed-length T-10A reply frame."""
-        n = self._response_length_for(cmd)
-        data = self.ser.read(n)
-        if len(data) < n:
-            # Fallback for adapters that chunk differently.
-            extra = self.ser.read_until(expected=b"\r\n", size=max(n, 64))
-            if extra and not data.endswith(extra):
-                data = (data + extra)[: max(n, len(data + extra))]
+        data = self._read_serial_reply(self.ser, self._response_length_for(cmd))
         return data.decode("ascii", errors="replace").strip()
 
     def _send_command(self, head_no: int, cmd: str, params: str = "") -> str:
@@ -212,6 +246,96 @@ class T10AClient(SensorClient):
         mant = int(compact[1:5])
         exp = int(compact[5]) - 4
         return float(sign * mant * (10**exp))
+
+    @classmethod
+    def _looks_like_t10a_reply(cls, raw: bytes, expected_cmd: str) -> bool:
+        if not raw:
+            return False
+        text = raw.decode("ascii", errors="replace").strip()
+        body = cls._strip_transport(text)
+        if len(body) < 4:
+            return False
+        if body[:2].isdigit() and body[2:4] == expected_cmd:
+            return True
+        return body[:2].isdigit() and "ERR" in body.upper()
+
+    @classmethod
+    def probe_port(
+        cls,
+        *,
+        port: str,
+        timeout_s: float = 1.0,
+        protocol: dict | None = None,
+        baudrate: int = 9600,
+        head_no: int = 0,
+        open_delay_s: float = 0.1,
+    ) -> bool:
+        protocol_cfg = protocol or {}
+        xonxoff = str(protocol_cfg.get("xonxoff", "true")).lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        inter_command_delay_s = float(protocol_cfg.get("inter_command_delay_s", 0.1))
+        measure_command = str(protocol_cfg.get("measure_command", "10"))
+        measure_params = str(protocol_cfg.get("measure_params", "0200"))
+        pc_mode_command = str(protocol_cfg.get("pc_mode_command", "54"))
+        pc_mode_params = str(protocol_cfg.get("pc_mode_params", "1 "))
+        pc_mode_head_no = int(protocol_cfg.get("pc_mode_head_no", 0))
+        short_reply_len = int(protocol_cfg.get("short_reply_len", _SHORT_REPLY_LEN))
+        long_reply_len = int(protocol_cfg.get("long_reply_len", _LONG_REPLY_LEN))
+        send_pc_mode = str(protocol_cfg.get("send_pc_mode", "true")).lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+
+        commands: list[tuple[int, str, str, int]] = []
+        if send_pc_mode:
+            commands.append((pc_mode_head_no, pc_mode_command, pc_mode_params, short_reply_len))
+        commands.append((head_no, measure_command, measure_params, long_reply_len))
+
+        ser = None
+        try:
+            ser = serial.Serial(
+                port=port,
+                baudrate=cls._coerce_baudrate(protocol_cfg.get("baudrate"), baudrate),
+                bytesize=serial.SEVENBITS,
+                parity=serial.PARITY_EVEN,
+                stopbits=serial.STOPBITS_ONE,
+                timeout=timeout_s,
+                xonxoff=xonxoff,
+            )
+            if open_delay_s > 0:
+                time.sleep(open_delay_s)
+
+            for probe_head_no, cmd, params, reply_len in commands:
+                frame = cls._build_probe_frame(
+                    head_no=probe_head_no,
+                    cmd=cmd,
+                    params=params,
+                    protocol=protocol_cfg,
+                )
+                ser.reset_input_buffer()
+                ser.write(frame)
+                ser.flush()
+                if inter_command_delay_s > 0:
+                    time.sleep(inter_command_delay_s)
+                raw = cls._read_serial_reply(ser, reply_len)
+                if cls._looks_like_t10a_reply(raw, cmd):
+                    return True
+            return False
+        except Exception as e:
+            logger.debug("T10A probe failed on %s: %s", port, e)
+            return False
+        finally:
+            if ser is not None:
+                try:
+                    ser.close()
+                except Exception:
+                    pass
 
     def _parse_measurement_reply(self, head_cfg: T10AHeadConfig, reply: str) -> float | None:
         """

--- a/svc/data/sensors_config.json
+++ b/svc/data/sensors_config.json
@@ -2,7 +2,7 @@
   "t10a": [
     {
       "device_id": "KM1",
-      "port": "COM5",
+      "port": "auto",
       "interval_s": 60,
       "timeout_s": 1.0,
       "protocol": {
@@ -39,7 +39,7 @@
     },
     {
       "device_id": "KM2",
-      "port": "COM4",
+      "port": "auto",
       "interval_s": 60,
       "timeout_s": 1.0,
       "protocol": {

--- a/svc/tests/test_jeti_specfirm_client.py
+++ b/svc/tests/test_jeti_specfirm_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import app.sensors.jeti_specfirm_client as jeti_mod
 from app.sensors.jeti_specfirm_client import JetiSpecfirmClient
 
 
@@ -40,3 +41,33 @@ def test_extract_spectrum_values_falls_back_to_flat_float_stream() -> None:
 
     vals = c._extract_spectrum_values(raw)
     assert vals == [10.0, 20.0, 30.0]
+
+
+def test_probe_port_recognizes_jeti_idn_reply(monkeypatch) -> None:
+    class FakeSerial:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.reads = 0
+            self.closed = False
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, payload):
+            self.payload = payload
+
+        def flush(self):
+            pass
+
+        def read(self, size):
+            self.reads += 1
+            if self.reads == 1:
+                return b"JETI_SDCM3 12345678\r"
+            return b""
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(jeti_mod.serial, "Serial", FakeSerial)
+
+    assert JetiSpecfirmClient.probe_port(port="COM7", baudrate=921600, timeout_s=0.1)

--- a/svc/tests/test_sensor_manager.py
+++ b/svc/tests/test_sensor_manager.py
@@ -4,6 +4,7 @@ import json
 from dataclasses import dataclass
 
 from app.sensors import manager
+from app.sensors import serial_autodetect
 from app.sensors.interface import SensorReading
 
 
@@ -29,6 +30,7 @@ def test_default_jeti_baudrate_uses_specbos_defaults() -> None:
     assert manager._default_jeti_baudrate({"device_id": "SPECBOS-1211-2"}) == 115200
     assert manager._default_jeti_baudrate({"label": "Jeti Spectraval 1511"}) == 921600
     assert manager._default_jeti_baudrate({"device_id": "SPECBOS-1211-2", "baudrate": 230400}) == 230400
+    assert manager._default_jeti_baudrate({"device_id": "SPECBOS-1211-2", "baudrate": "auto"}) == 115200
 
 
 @dataclass
@@ -40,6 +42,20 @@ class FakeClient:
         if self.source == "real":
             return []
         return [SensorReading(sensor_id=f"{self.id}-SIM", metric="simulated", value=1.0, ts=1.0)]
+
+
+@dataclass
+class FakePortInfo:
+    device: str
+    name: str = ""
+    description: str = ""
+    hwid: str = ""
+    manufacturer: str = ""
+    product: str = ""
+    serial_number: str = ""
+    location: str = ""
+    vid: int | None = None
+    pid: int | None = None
 
 
 def _sensor_config() -> dict:
@@ -204,6 +220,81 @@ def test_real_mode_does_not_emit_simulated_sensor_readings(monkeypatch) -> None:
     readings = [r for client, _ in clients for r in client.poll()]
 
     assert readings == []
+
+
+def test_real_mode_autodetects_serial_ports_and_reserves_them(monkeypatch) -> None:
+    monkeypatch.setattr(manager, "MODE", "real")
+    monkeypatch.setattr(
+        manager,
+        "_load_config",
+        lambda: {
+            "t10a": [
+                {
+                    "device_id": "KM1",
+                    "port": "auto",
+                    "heads": [{"head_no": 0, "sensor_id": "T10A1-H1", "label": "T10A"}],
+                }
+            ],
+            "jeti_spectraval": [
+                {
+                    "sensor_id": "JETI-00",
+                    "device_id": "JETI",
+                    "transport": "serial_scpi",
+                    "port": "auto",
+                    "baudrate_candidates": [115200, 921600],
+                }
+            ],
+            "eko_ms90_plus": [],
+        },
+    )
+    monkeypatch.setattr(
+        serial_autodetect.list_ports,
+        "comports",
+        lambda: [FakePortInfo("COM3"), FakePortInfo("COM4")],
+    )
+
+    registered = {}
+    monkeypatch.setattr(manager, "register_sensor", lambda **kwargs: registered.setdefault(kwargs["sensor_id"], kwargs))
+    monkeypatch.setattr(manager, "delete_sensor_readings_for_ids", lambda sensor_ids: None)
+    monkeypatch.setattr(manager, "prune_sensors_to_ids", lambda sensor_ids: None)
+
+    class FakeT10AClient:
+        @staticmethod
+        def probe_port(**kwargs):
+            return kwargs["port"] == "COM3"
+
+        def __init__(self, **kwargs):
+            self.source = "real"
+            self.kwargs = kwargs
+
+        def poll(self):
+            return []
+
+    class FakeJetiClient:
+        @staticmethod
+        def probe_port(**kwargs):
+            return kwargs["port"] == "COM4" and kwargs["baudrate"] == 921600
+
+        def __init__(self, **kwargs):
+            self.source = "real"
+            self.kwargs = kwargs
+
+        def poll(self):
+            return []
+
+    monkeypatch.setattr(manager, "T10AClient", FakeT10AClient)
+    monkeypatch.setattr(manager, "JetiSpecfirmClient", FakeJetiClient)
+
+    clients = manager._make_clients_from_config()
+
+    assert len(clients) == 2
+    t10a_client = clients[0][0]
+    jeti_client = clients[1][0]
+    assert t10a_client.kwargs["port"] == "COM3"
+    assert jeti_client.kwargs["port"] == "COM4"
+    assert jeti_client.kwargs["baudrate"] == 921600
+    assert registered["T10A1-H1"]["config"]["port"] == "COM3"
+    assert registered["JETI-00"]["config"]["port"] == "COM4"
 
 
 def test_real_mode_clears_stale_readings_for_configured_sensors(monkeypatch) -> None:

--- a/svc/tests/test_serial_autodetect.py
+++ b/svc/tests/test_serial_autodetect.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.sensors import serial_autodetect
+
+
+@dataclass
+class FakePortInfo:
+    device: str
+    name: str = ""
+    description: str = ""
+    hwid: str = ""
+    manufacturer: str = ""
+    product: str = ""
+    serial_number: str = ""
+    location: str = ""
+    vid: int | None = None
+    pid: int | None = None
+
+
+def test_find_serial_port_filters_match_hints_and_reserved_ports(monkeypatch) -> None:
+    monkeypatch.setattr(
+        serial_autodetect.list_ports,
+        "comports",
+        lambda: [
+            FakePortInfo("COM10", description="Reserved T-10A", serial_number="T10A-01"),
+            FakePortInfo(
+                "COM3",
+                description="USB Serial JETI",
+                serial_number="JETI-ABC",
+                vid=0x1234,
+            ),
+        ],
+    )
+    probed: list[str] = []
+
+    port = serial_autodetect.find_serial_port(
+        sensor_name="JETI",
+        requested_port="auto",
+        reserved_ports={"COM10"},
+        match={"serial_number": "jeti-abc", "vid": "0x1234"},
+        probe=lambda candidate_port: probed.append(candidate_port) or True,
+    )
+
+    assert port == "COM3"
+    assert probed == ["COM3"]
+
+
+def test_list_serial_port_candidates_uses_natural_com_order(monkeypatch) -> None:
+    monkeypatch.setattr(
+        serial_autodetect.list_ports,
+        "comports",
+        lambda: [
+            FakePortInfo("COM10"),
+            FakePortInfo("COM2"),
+            FakePortInfo("COM1"),
+        ],
+    )
+
+    candidates = serial_autodetect.list_serial_port_candidates()
+
+    assert [candidate.device for candidate in candidates] == ["COM1", "COM2", "COM10"]

--- a/svc/tests/test_t10a_client.py
+++ b/svc/tests/test_t10a_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import app.sensors.t10a_client as t10a_mod
 from app.sensors.t10a_client import T10AClient, T10AHeadConfig
 
 
@@ -71,3 +72,33 @@ def test_build_frame_contains_stx_etx_bcc() -> None:
     assert frame.startswith(b"\x02")
     assert b"\x03" in frame
     assert frame.endswith(b"\r\n")
+
+
+def test_probe_port_recognizes_t10a_pc_mode_reply(monkeypatch) -> None:
+    class FakeSerial:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.closed = False
+
+        def reset_input_buffer(self):
+            pass
+
+        def write(self, frame):
+            self.frame = frame
+
+        def flush(self):
+            pass
+
+        def read(self, expected_len):
+            return b"\x0200540000\x0312\r\n"[:expected_len]
+
+        def read_until(self, expected=b"\r\n", size=64):
+            return b""
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(t10a_mod.serial, "Serial", FakeSerial)
+    monkeypatch.setattr(t10a_mod.time, "sleep", lambda delay: None)
+
+    assert T10AClient.probe_port(port="COM9")


### PR DESCRIPTION
## Summary
Adds auto-detection for sensor COM ports so T-10A and JETI serial sensors can use `"port": "auto"` instead of fixed COM numbers.

## Type
- [x] Feature
- [ ] Fix
- [x] Docs
- [ ] Chore

## Testing
- Ran `uv run pytest tests`
- All tests passed

## Risk and rollout
Risk: multiple identical sensors may need `port_match` hints to avoid choosing the wrong device. Rollback: set the config back to fixed COM ports.

## Checklist
- [ ] Issue linked if applicable
- [x] Added or updated docs
- [x] CI green
- [ ] At least one reviewer not the author