### PR TITLE
Add the ability to label T10 heads (retains overall name for clarity)…

### DIFF
--- a/svc/app/models.py
+++ b/svc/app/models.py
@@ -85,6 +85,11 @@ class SensorInfo(BaseModel):
     config: Dict = Field(default_factory=dict)
 
 
+class SensorLabelUpdateRequest(BaseModel):
+    custom_label: Optional[str] = None
+    device_custom_label: Optional[str] = None
+
+
 class SensorReadingResponse(BaseModel):
     sensor_id: str
     metric: str

--- a/svc/app/routes.py
+++ b/svc/app/routes.py
@@ -5,7 +5,7 @@ from .models import (
     Panel, Group, CommandRequest, CommandResult, GroupCreate, GroupUpdate, 
     AuditEntry, HealthResponse, DeleteGroupResponse, ErrorResponse, SensorInfo,
     SensorReadingResponse, SensorLogEntry, RoutineRequest, RoutineStatusResponse, SavedRoutine,
-    SensorSpectrumResponse
+    SensorSpectrumResponse, SensorLabelUpdateRequest
 )
 from typing import List, Optional
 import csv
@@ -623,4 +623,28 @@ def create_saved_routine(body: SavedRoutine) -> SavedRoutine:
 )
 def delete_saved_routine_endpoint(name: str):
     delete_saved_routine(name)
+    return {"ok": True}
+
+
+@router.patch(
+    "/sensors/{sensor_id}",
+    summary="Update sensor custom labels",
+    tags=["Sensors"],
+)
+def patch_sensor_labels(
+    sensor_id: str,
+    req: SensorLabelUpdateRequest,
+) -> dict:
+    from app.sensors.manager import update_sensor_labels
+    
+    success = update_sensor_labels(
+        sensor_id=sensor_id,
+        custom_label=req.custom_label,
+        device_custom_label=req.device_custom_label,
+    )
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Sensor T-10A head with ID {sensor_id} not found in configuration."
+        )
     return {"ok": True}

--- a/svc/app/sensors/manager.py
+++ b/svc/app/sensors/manager.py
@@ -150,6 +150,8 @@ def _make_clients_from_config() -> list[tuple[SensorClient, float]]:
                     "interval_s": interval_s,
                     "timeout_s": timeout_s,
                     "protocol": protocol_cfg,
+                    "custom_label": h.get("custom_label"),
+                    "device_custom_label": dev_cfg.get("custom_label"),
                 },
             )
             configured_sensor_ids.add(hc.sensor_id)
@@ -491,3 +493,97 @@ def stop_sensor_workers() -> None:
 
     _workers = []
     _clients = []
+
+
+def update_sensor_labels(
+    sensor_id: str,
+    custom_label: str | None = None,
+    device_custom_label: str | None = None,
+) -> bool:
+    """
+    Update the custom labels for a T-10A head and/or body.
+    Updates the SQLite database only.
+    """
+    config_path = _get_sensors_config_file()
+    if not os.path.exists(config_path):
+        logger.warning("No sensors_config.json found at %s", config_path)
+        return False
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            cfg = json.load(f)
+    except Exception as e:
+        logger.error("Failed to load sensors config for update: %s", e)
+        return False
+
+    found = False
+    target_device_id = None
+
+    # Loop through t10a devices to find the matching head and get its device_id
+    for dev_cfg in cfg.get("t10a", []):
+        for h in dev_cfg.get("heads", []):
+            if h.get("sensor_id") == sensor_id:
+                found = True
+                target_device_id = dev_cfg.get("device_id")
+                break
+        if found:
+            break
+
+    if not found:
+        return False
+
+    # Update SQLite database
+    from app.state import _db_connection
+    import sqlite3
+
+    try:
+        with _db_connection(row_factory=sqlite3.Row) as conn:
+            # First, update the head custom_label in its config_json
+            row = conn.execute(
+                "SELECT config_json FROM sensors WHERE id = ?", (sensor_id,)
+            ).fetchone()
+            if row:
+                config = json.loads(row["config_json"] or "{}")
+                if custom_label is not None:
+                    if custom_label.strip() == "":
+                        config.pop("custom_label", None)
+                    else:
+                        config["custom_label"] = custom_label.strip()
+                
+                if device_custom_label is not None:
+                    if device_custom_label.strip() == "":
+                        config.pop("device_custom_label", None)
+                    else:
+                        config["device_custom_label"] = device_custom_label.strip()
+                
+                conn.execute(
+                    "UPDATE sensors SET config_json = ? WHERE id = ?",
+                    (json.dumps(config), sensor_id),
+                )
+
+            # If device_custom_label is updated, we must update all heads belonging to this device_id
+            if device_custom_label is not None and target_device_id:
+                rows = conn.execute(
+                    "SELECT id, config_json FROM sensors WHERE kind = 't10a'"
+                ).fetchall()
+                for r in rows:
+                    h_id = r["id"]
+                    if h_id == sensor_id:
+                        continue # Already updated
+                    
+                    h_config = json.loads(r["config_json"] or "{}")
+                    if h_config.get("device_id") == target_device_id:
+                        if device_custom_label.strip() == "":
+                            h_config.pop("device_custom_label", None)
+                        else:
+                            h_config["device_custom_label"] = device_custom_label.strip()
+                        
+                        conn.execute(
+                            "UPDATE sensors SET config_json = ? WHERE id = ?",
+                            (json.dumps(h_config), h_id),
+                        )
+    except Exception as e:
+        logger.error("Failed to update database with custom labels: %s", e)
+        return False
+
+    return True

--- a/svc/app/state.py
+++ b/svc/app/state.py
@@ -486,8 +486,22 @@ def register_sensor(
     Idempotently register a sensor; if it already exists we just update its metadata.
     """
     _ensure_sensor_db()
-    cfg_json = json.dumps(config)
-    with _db_connection() as conn:
+    with _db_connection(row_factory=sqlite3.Row) as conn:
+        # Check if it already exists to preserve custom labels
+        row = conn.execute(
+            "SELECT config_json FROM sensors WHERE id = ?", (sensor_id,)
+        ).fetchone()
+        if row:
+            try:
+                existing_config = json.loads(row["config_json"] or "{}")
+                if "custom_label" in existing_config:
+                    config["custom_label"] = existing_config["custom_label"]
+                if "device_custom_label" in existing_config:
+                    config["device_custom_label"] = existing_config["device_custom_label"]
+            except Exception:
+                pass
+
+        cfg_json = json.dumps(config)
         conn.execute(
             """
             INSERT INTO sensors (id, kind, label, location, config_json)

--- a/svc/tests/test_sensor_labels.py
+++ b/svc/tests/test_sensor_labels.py
@@ -1,0 +1,178 @@
+import json
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+from app.state import register_sensor, list_sensors
+from app.sensors import manager
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def temp_db(tmp_path, monkeypatch):
+    """Create a temporary database and config file for testing."""
+    db_file = tmp_path / "test_audit.db"
+    monkeypatch.setattr("app.state.AUDIT_DB_FILE", str(db_file))
+    monkeypatch.setattr("app.config.AUDIT_DB_FILE", str(db_file))
+    
+    config_file = tmp_path / "sensors_config.json"
+    dummy_config = {
+        "t10a": [
+            {
+                "device_id": "KM1",
+                "port": "COM3",
+                "interval_s": 60,
+                "heads": [
+                    {"head_no": 0, "sensor_id": "T10A1-H1", "label": "T-10A #1 Head 1"},
+                    {"head_no": 1, "sensor_id": "T10A1-H2", "label": "T-10A #1 Head 2"}
+                ]
+            }
+        ]
+    }
+    config_file.write_text(json.dumps(dummy_config), encoding="utf-8")
+    monkeypatch.setattr(manager, "_get_sensors_config_file", lambda: str(config_file))
+    
+    if db_file.exists():
+        db_file.unlink()
+    
+    yield str(db_file)
+    
+    if db_file.exists():
+        db_file.unlink()
+
+
+def test_update_sensor_labels_success():
+    # Register sensors in the DB
+    register_sensor(
+        sensor_id="T10A1-H1",
+        kind="t10a",
+        label="T-10A #1 Head 1",
+        location=None,
+        config={"device_id": "KM1", "port": "COM3", "head_no": 0}
+    )
+    register_sensor(
+        sensor_id="T10A1-H2",
+        kind="t10a",
+        label="T-10A #1 Head 2",
+        location=None,
+        config={"device_id": "KM1", "port": "COM3", "head_no": 1}
+    )
+
+    # Invoke update
+    success = manager.update_sensor_labels(
+        sensor_id="T10A1-H1",
+        custom_label="Office Desk",
+        device_custom_label="Main Body"
+    )
+    assert success is True
+
+    # 1. Verify config file is NOT updated (labels remain untouched in sensors_config.json)
+    config_path = manager._get_sensors_config_file()
+    with open(config_path, "r") as f:
+        cfg = json.load(f)
+    
+    dev = cfg["t10a"][0]
+    assert "custom_label" not in dev
+    assert "custom_label" not in dev["heads"][0]
+
+    # 2. Verify database is updated
+    db_sensors = list_sensors()
+    h1 = next(s for s in db_sensors if s["id"] == "T10A1-H1")
+    h2 = next(s for s in db_sensors if s["id"] == "T10A1-H2")
+
+    assert h1["config"]["custom_label"] == "Office Desk"
+    assert h1["config"]["device_custom_label"] == "Main Body"
+    
+    # Verify the body custom label cascaded to the other head belonging to the same device
+    assert h2["config"]["device_custom_label"] == "Main Body"
+    assert "custom_label" not in h2["config"]
+
+
+def test_update_sensor_labels_clears_labels():
+    register_sensor(
+        sensor_id="T10A1-H1",
+        kind="t10a",
+        label="T-10A #1 Head 1",
+        location=None,
+        config={"device_id": "KM1", "port": "COM3", "head_no": 0, "custom_label": "Office Desk", "device_custom_label": "Main Body"}
+    )
+    
+    # Invoke update with empty strings to clear labels
+    success = manager.update_sensor_labels(
+        sensor_id="T10A1-H1",
+        custom_label="",
+        device_custom_label=""
+    )
+    assert success is True
+
+    # 1. Verify config file is NOT updated (labels remain untouched/empty in sensors_config.json)
+    config_path = manager._get_sensors_config_file()
+    with open(config_path, "r") as f:
+        cfg = json.load(f)
+    assert "custom_label" not in cfg["t10a"][0]
+    assert "custom_label" not in cfg["t10a"][0]["heads"][0]
+
+    # 2. Verify database is updated (keys popped)
+    db_sensors = list_sensors()
+    h1 = next(s for s in db_sensors if s["id"] == "T10A1-H1")
+    assert "custom_label" not in h1["config"]
+    assert "device_custom_label" not in h1["config"]
+
+
+def test_register_sensor_preserves_database_custom_labels():
+    # 1. Register a sensor
+    register_sensor(
+        sensor_id="T10A1-H1",
+        kind="t10a",
+        label="T-10A #1 Head 1",
+        location=None,
+        config={"device_id": "KM1", "port": "COM3", "head_no": 0}
+    )
+    
+    # 2. Update its labels
+    success = manager.update_sensor_labels(
+        sensor_id="T10A1-H1",
+        custom_label="Office Desk",
+        device_custom_label="Main Body"
+    )
+    assert success is True
+    
+    # 3. Simulate startup/reload by reregistering the sensor with clean config (as loaded from file)
+    register_sensor(
+        sensor_id="T10A1-H1",
+        kind="t10a",
+        label="T-10A #1 Head 1",
+        location=None,
+        config={"device_id": "KM1", "port": "COM3", "head_no": 0}
+    )
+    
+    # 4. Verify custom labels are still preserved in the database config
+    db_sensors = list_sensors()
+    h1 = next(s for s in db_sensors if s["id"] == "T10A1-H1")
+    assert h1["config"]["custom_label"] == "Office Desk"
+    assert h1["config"]["device_custom_label"] == "Main Body"
+
+
+def test_patch_sensor_labels_api_endpoint():
+    # Register sensors in the DB
+    register_sensor(
+        sensor_id="T10A1-H1",
+        kind="t10a",
+        label="T-10A #1 Head 1",
+        location=None,
+        config={"device_id": "KM1", "port": "COM3", "head_no": 0}
+    )
+
+    response = client.patch(
+        "/sensors/T10A1-H1",
+        json={"custom_label": "Desk", "device_custom_label": "Body"}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    # Verify invalid sensor ID yields 404
+    response_404 = client.patch(
+        "/sensors/NON-EXISTENT",
+        json={"custom_label": "Desk"}
+    )
+    assert response_404.status_code == 404

--- a/web/src/AppHMI.tsx
+++ b/web/src/AppHMI.tsx
@@ -253,6 +253,9 @@ export default function AppHMI() {
     }, []);
 
     const [spectralModal, setSpectralModal] = useState<{ sensorId: string; fixedTs?: number } | null>(null);
+    const [editingSensorId, setEditingSensorId] = useState<string | null>(null);
+    const editCustomLabelRef = useRef<HTMLInputElement>(null);
+    const editDeviceCustomLabelRef = useRef<HTMLInputElement>(null);
 
     const connectedSensorList = sortSensorsForDisplay(getConnectedSensors(sensors, latestMetrics));
     const sensorListForControls = connectedSensorList.length > 0 ? connectedSensorList : sortSensorsForDisplay(sensors);
@@ -840,7 +843,11 @@ export default function AppHMI() {
                                         <label
                                             key={`visibility-${sensor.id}`}
                                             className={`sensor-visibility-row ${active ? "active" : ""}`}
-                                            title={`${sensor.label || sensor.id} (${sensorKindLabel})`}
+                                            title={
+                                                sensor.config?.custom_label
+                                                    ? `${sensor.config.custom_label} (${sensor.label || sensor.id}) (${sensor.config.device_custom_label ? `${sensor.config.device_custom_label} (${sensorKindLabel})` : sensorKindLabel})`
+                                                    : `${sensor.label || sensor.id} (${sensorKindLabel})`
+                                            }
                                         >
                                             <input
                                                 type="checkbox"
@@ -854,8 +861,30 @@ export default function AppHMI() {
                                                     );
                                                 }}
                                             />
-                                            <span className="sensor-visibility-name">{sensor.label || sensor.id}</span>
-                                            <span className="sensor-visibility-kind">{sensorKindLabel}</span>
+                                            <span className="sensor-visibility-name">
+                                                {sensor.config?.custom_label ? (
+                                                    <>
+                                                        {sensor.config.custom_label}{" "}
+                                                        <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.85em", fontWeight: "normal" }}>
+                                                            ({sensor.label || sensor.id})
+                                                        </span>
+                                                    </>
+                                                ) : (
+                                                    sensor.label || sensor.id
+                                                )}
+                                            </span>
+                                            <span className="sensor-visibility-kind">
+                                                {sensor.config?.device_custom_label ? (
+                                                    <>
+                                                        {sensor.config.device_custom_label}{" "}
+                                                        <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.85em", fontWeight: "normal" }}>
+                                                            ({sensorKindLabel})
+                                                        </span>
+                                                    </>
+                                                ) : (
+                                                    sensorKindLabel
+                                                )}
+                                            </span>
                                         </label>
                                     );
                                 })}
@@ -903,30 +932,135 @@ export default function AppHMI() {
                         return (
                             <div key={sensor.id} className="room-section sensor-card sensor-card-no-data" style={{ marginTop: 20 }}>
                                 <div className="room-header sensor-card-header">
-                                    <h2 className="room-title">{sensor.label || sensor.id}</h2>
-                                    <div className="room-stats">
-                                        <span>{sensorKindLabel}</span>
-                                        {sensor.location && <span style={{ marginLeft: 8 }}>{sensor.location}</span>}
-                                        <span style={{ marginLeft: 8 }}>not reporting</span>
-                                        {sensor.kind === "jeti_spectraval" && (
-                                            <button
-                                                className="hmi-manage-btn"
-                                                onClick={() => setSpectralModal({ sensorId: sensor.id })}
-                                                style={{ marginLeft: 12, marginRight: 8, padding: "2px 8px", fontSize: "11px", height: "auto" }}
-                                                title="View real-time spectral irradiance graph"
-                                            >
-                                                View Spectrum
-                                            </button>
-                                        )}
-                                        <button
-                                            type="button"
-                                            className="sensor-card-hide-btn"
-                                            onClick={() => hideSensor(sensor.id)}
-                                            title={`Hide ${sensor.label || sensor.id}`}
-                                        >
-                                            Hide
-                                        </button>
-                                    </div>
+                                    {editingSensorId === sensor.id ? (
+                                        <div className="sensor-edit-form" style={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%', padding: '4px 0' }}>
+                                            <div style={{ display: 'flex', gap: '12px', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+                                                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                                    <span style={{ fontSize: '11px', color: 'var(--hmi-text-muted)', fontWeight: 500 }}>Head Label</span>
+                                                    <input
+                                                        type="text"
+                                                        className="hmi-input"
+                                                        ref={editCustomLabelRef}
+                                                        defaultValue={sensor.config?.custom_label || ""}
+                                                        placeholder={sensor.label || sensor.id}
+                                                        style={{ padding: '6px 10px', fontSize: '13px', background: 'var(--hmi-bg-dark)', border: '1px solid var(--hmi-border)', color: 'var(--hmi-text)', borderRadius: '4px', width: '160px' }}
+                                                    />
+                                                </div>
+                                                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                                    <span style={{ fontSize: '11px', color: 'var(--hmi-text-muted)', fontWeight: 500 }}>Body Label</span>
+                                                    <input
+                                                        type="text"
+                                                        className="hmi-input"
+                                                        ref={editDeviceCustomLabelRef}
+                                                        defaultValue={sensor.config?.device_custom_label || ""}
+                                                        placeholder={sensorKindLabel}
+                                                        style={{ padding: '6px 10px', fontSize: '13px', background: 'var(--hmi-bg-dark)', border: '1px solid var(--hmi-border)', color: 'var(--hmi-text)', borderRadius: '4px', width: '160px' }}
+                                                    />
+                                                </div>
+                                                <div style={{ display: 'flex', gap: '8px' }}>
+                                                    <button
+                                                        type="button"
+                                                        className="hmi-manage-btn"
+                                                        onClick={async () => {
+                                                            try {
+                                                                const customLabel = editCustomLabelRef.current?.value || "";
+                                                                const deviceCustomLabel = editDeviceCustomLabelRef.current?.value || "";
+                                                                await api.updateSensorLabels(sensor.id, customLabel, deviceCustomLabel);
+                                                                setEditingSensorId(null);
+                                                                await refresh();
+                                                            } catch (err) {
+                                                                console.error("Failed to update labels:", err);
+                                                                alert("Failed to update labels: " + String(err));
+                                                            }
+                                                        }}
+                                                        style={{ padding: '6px 12px', fontSize: '12px', height: '31px' }}
+                                                    >
+                                                        Save
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className="hmi-manage-btn"
+                                                        onClick={() => setEditingSensorId(null)}
+                                                        style={{ padding: '6px 12px', fontSize: '12px', background: 'transparent', border: '1px solid var(--hmi-border)', height: '31px' }}
+                                                    >
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <>
+                                            <h2 className="room-title" style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+                                                {sensor.config?.custom_label ? (
+                                                    <>
+                                                        {sensor.config.custom_label}{" "}
+                                                        <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.75em", fontWeight: "normal" }}>
+                                                            ({sensor.label || sensor.id})
+                                                        </span>
+                                                    </>
+                                                ) : (
+                                                    sensor.label || sensor.id
+                                                )}
+                                                {sensor.kind === "t10a" && (
+                                                    <button
+                                                        type="button"
+                                                        className="hmi-edit-icon-btn"
+                                                        onClick={() => {
+                                                            setEditingSensorId(sensor.id);
+                                                        }}
+                                                        title="Edit labels"
+                                                        style={{
+                                                            background: 'none',
+                                                            border: 'none',
+                                                            color: 'var(--hmi-text-muted)',
+                                                            cursor: 'pointer',
+                                                            padding: 0,
+                                                            display: 'inline-flex',
+                                                            alignItems: 'center'
+                                                        }}
+                                                    >
+                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: "16px", height: "16px" }}>
+                                                            <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.83 20.013a4.5 4.5 0 01-1.897 1.13l-3.885 1.206 1.207-3.885a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
+                                                        </svg>
+                                                    </button>
+                                                )}
+                                            </h2>
+                                            <div className="room-stats">
+                                                <span>
+                                                    {sensor.config?.device_custom_label ? (
+                                                        <>
+                                                            {sensor.config.device_custom_label}{" "}
+                                                            <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.85em", fontWeight: "normal" }}>
+                                                                ({sensorKindLabel})
+                                                            </span>
+                                                        </>
+                                                    ) : (
+                                                        sensorKindLabel
+                                                    )}
+                                                </span>
+                                                {sensor.location && <span style={{ marginLeft: 8 }}>{sensor.location}</span>}
+                                                <span style={{ marginLeft: 8 }}>not reporting</span>
+                                                {sensor.kind === "jeti_spectraval" && (
+                                                    <button
+                                                        className="hmi-manage-btn"
+                                                        onClick={() => setSpectralModal({ sensorId: sensor.id })}
+                                                        style={{ marginLeft: 12, marginRight: 8, padding: "2px 8px", fontSize: "11px", height: "auto" }}
+                                                        title="View real-time spectral irradiance graph"
+                                                    >
+                                                        View Spectrum
+                                                    </button>
+                                                )}
+                                                <button
+                                                    type="button"
+                                                    className="sensor-card-hide-btn"
+                                                    onClick={() => hideSensor(sensor.id)}
+                                                    title={`Hide ${sensor.config?.custom_label || sensor.label || sensor.id}`}
+                                                >
+                                                    Hide
+                                                </button>
+                                            </div>
+                                        </>
+                                    )}
                                 </div>
                                 <div className="sensor-card-layout">
                                     <div className="sensor-metrics-panel">
@@ -946,31 +1080,136 @@ export default function AppHMI() {
                     return (
                         <div key={sensor.id} className="room-section sensor-card" style={{ marginTop: 20 }}>
                             <div className="room-header sensor-card-header">
-                                <h2 className="room-title">{sensor.label || sensor.id}</h2>
-                                <div className="room-stats">
-                                    <span>{sensorKindLabel}</span>
-                                    {sensor.location && <span style={{ marginLeft: 8 }}>{sensor.location}</span>}
-                                    <span style={{ marginLeft: 8 }}>{orderedMetricNames.length} metrics</span>
-                                    {sensor.kind === "jeti_spectraval" && (
-                                        <button
-                                            className="hmi-manage-btn"
-                                            onClick={() => setSpectralModal({ sensorId: sensor.id })}
-                                            style={{ marginLeft: 12, marginRight: 8, padding: "2px 8px", fontSize: "11px", height: "auto" }}
-                                            title="View real-time spectral irradiance graph"
-                                        >
-                                            View Spectrum
-                                        </button>
+                                    {editingSensorId === sensor.id ? (
+                                        <div className="sensor-edit-form" style={{ display: 'flex', flexDirection: 'column', gap: '8px', width: '100%', padding: '4px 0' }}>
+                                            <div style={{ display: 'flex', gap: '12px', alignItems: 'flex-end', flexWrap: 'wrap' }}>
+                                                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                                    <span style={{ fontSize: '11px', color: 'var(--hmi-text-muted)', fontWeight: 500 }}>Head Label</span>
+                                                    <input
+                                                        type="text"
+                                                        className="hmi-input"
+                                                        ref={editCustomLabelRef}
+                                                        defaultValue={sensor.config?.custom_label || ""}
+                                                        placeholder={sensor.label || sensor.id}
+                                                        style={{ padding: '6px 10px', fontSize: '13px', background: 'var(--hmi-bg-dark)', border: '1px solid var(--hmi-border)', color: 'var(--hmi-text)', borderRadius: '4px', width: '160px' }}
+                                                    />
+                                                </div>
+                                                <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+                                                    <span style={{ fontSize: '11px', color: 'var(--hmi-text-muted)', fontWeight: 500 }}>Body Label</span>
+                                                    <input
+                                                        type="text"
+                                                        className="hmi-input"
+                                                        ref={editDeviceCustomLabelRef}
+                                                        defaultValue={sensor.config?.device_custom_label || ""}
+                                                        placeholder={sensorKindLabel}
+                                                        style={{ padding: '6px 10px', fontSize: '13px', background: 'var(--hmi-bg-dark)', border: '1px solid var(--hmi-border)', color: 'var(--hmi-text)', borderRadius: '4px', width: '160px' }}
+                                                    />
+                                                </div>
+                                                <div style={{ display: 'flex', gap: '8px' }}>
+                                                    <button
+                                                        type="button"
+                                                        className="hmi-manage-btn"
+                                                        onClick={async () => {
+                                                            try {
+                                                                const customLabel = editCustomLabelRef.current?.value || "";
+                                                                const deviceCustomLabel = editDeviceCustomLabelRef.current?.value || "";
+                                                                await api.updateSensorLabels(sensor.id, customLabel, deviceCustomLabel);
+                                                                setEditingSensorId(null);
+                                                                await refresh();
+                                                            } catch (err) {
+                                                                console.error("Failed to update labels:", err);
+                                                                alert("Failed to update labels: " + String(err));
+                                                            }
+                                                        }}
+                                                        style={{ padding: '6px 12px', fontSize: '12px', height: '31px' }}
+                                                    >
+                                                        Save
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className="hmi-manage-btn"
+                                                        onClick={() => setEditingSensorId(null)}
+                                                        style={{ padding: '6px 12px', fontSize: '12px', background: 'transparent', border: '1px solid var(--hmi-border)', height: '31px' }}
+                                                    >
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <>
+                                            <h2 className="room-title" style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+                                                {sensor.config?.custom_label ? (
+                                                    <>
+                                                        {sensor.config.custom_label}{" "}
+                                                        <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.75em", fontWeight: "normal" }}>
+                                                            ({sensor.label || sensor.id})
+                                                        </span>
+                                                    </>
+                                                ) : (
+                                                    sensor.label || sensor.id
+                                                )}
+                                                {sensor.kind === "t10a" && (
+                                                    <button
+                                                        type="button"
+                                                        className="hmi-edit-icon-btn"
+                                                        onClick={() => {
+                                                            setEditingSensorId(sensor.id);
+                                                        }}
+                                                        title="Edit labels"
+                                                        style={{
+                                                            background: 'none',
+                                                            border: 'none',
+                                                            color: 'var(--hmi-text-muted)',
+                                                            cursor: 'pointer',
+                                                            padding: 0,
+                                                            display: 'inline-flex',
+                                                            alignItems: 'center'
+                                                        }}
+                                                    >
+                                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" style={{ width: "16px", height: "16px" }}>
+                                                            <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L6.83 20.013a4.5 4.5 0 01-1.897 1.13l-3.885 1.206 1.207-3.885a4.5 4.5 0 011.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
+                                                        </svg>
+                                                    </button>
+                                                )}
+                                            </h2>
+                                            <div className="room-stats">
+                                                <span>
+                                                    {sensor.config?.device_custom_label ? (
+                                                        <>
+                                                            {sensor.config.device_custom_label}{" "}
+                                                            <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.85em", fontWeight: "normal" }}>
+                                                                ({sensorKindLabel})
+                                                            </span>
+                                                        </>
+                                                    ) : (
+                                                        sensorKindLabel
+                                                    )}
+                                                </span>
+                                                {sensor.location && <span style={{ marginLeft: 8 }}>{sensor.location}</span>}
+                                                <span style={{ marginLeft: 8 }}>{orderedMetricNames.length} metrics</span>
+                                                {sensor.kind === "jeti_spectraval" && (
+                                                    <button
+                                                        className="hmi-manage-btn"
+                                                        onClick={() => setSpectralModal({ sensorId: sensor.id })}
+                                                        style={{ marginLeft: 12, marginRight: 8, padding: "2px 8px", fontSize: "11px", height: "auto" }}
+                                                        title="View real-time spectral irradiance graph"
+                                                    >
+                                                        View Spectrum
+                                                    </button>
+                                                )}
+                                                <button
+                                                    type="button"
+                                                    className="sensor-card-hide-btn"
+                                                    onClick={() => hideSensor(sensor.id)}
+                                                    title={`Hide ${sensor.config?.custom_label || sensor.label || sensor.id}`}
+                                                >
+                                                    Hide
+                                                </button>
+                                            </div>
+                                        </>
                                     )}
-                                    <button
-                                        type="button"
-                                        className="sensor-card-hide-btn"
-                                        onClick={() => hideSensor(sensor.id)}
-                                        title={`Hide ${sensor.label || sensor.id}`}
-                                    >
-                                        Hide
-                                    </button>
                                 </div>
-                            </div>
 
                             <div className="sensor-card-layout">
                                 <div className="sensor-metrics-panel">
@@ -1031,7 +1270,7 @@ export default function AppHMI() {
                                     <LiveGraph
                                         sensorId={sensor.id}
                                         metric={selectedGraphMetric}
-                                        label={`${sensor.label || sensor.id} - ${METRIC_LABELS[selectedGraphMetric] || selectedGraphMetric}`}
+                                        label={`${sensor.config?.custom_label ? `${sensor.config.custom_label} (${sensor.label || sensor.id})` : (sensor.label || sensor.id)} - ${METRIC_LABELS[selectedGraphMetric] || selectedGraphMetric}`}
                                         yAxisLabel={metricAxisLabel(selectedGraphMetric)}
                                         valueFormatter={(value) => value != null ? formatMetricValue(selectedGraphMetric, value) : "N/A"}
                                         color={sensorGraphColor(sensor.kind)}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -181,6 +181,14 @@ export const api = {
         document.body.removeChild(a);
     },
     listSensors: () => http<SensorInfo[]>("/sensors"),
+    updateSensorLabels: (sensorId: string, customLabel: string, deviceCustomLabel: string) =>
+        http<{ ok: boolean }>(`/sensors/${encodeURIComponent(sensorId)}`, {
+            method: "PATCH",
+            body: JSON.stringify({
+                custom_label: customLabel,
+                device_custom_label: deviceCustomLabel
+            })
+        }),
     getLatestMetrics: () => http<SensorReadingResponse[]>("/metrics/latest"),
     getMetricHistory: (sensorId: string, metric: string, tsFrom: number, tsTo: number) =>
         http<SensorReadingResponse[]>(`/metrics/history?sensor_id=${encodeURIComponent(sensorId)}&metric=${encodeURIComponent(metric)}&ts_from=${tsFrom}&ts_to=${tsTo}`),

--- a/web/src/components/LiveGraph.tsx
+++ b/web/src/components/LiveGraph.tsx
@@ -13,7 +13,7 @@ interface LiveGraphProps {
     valueFormatter?: (value: number | undefined) => string;
 }
 
-export default function LiveGraph({ sensorId, metric, color = "#8884d8", label, height = 300, variant = "card", yAxisLabel, valueFormatter }: LiveGraphProps) {
+function LiveGraph({ sensorId, metric, color = "#8884d8", label, height = 300, variant = "card", yAxisLabel, valueFormatter }: LiveGraphProps) {
     const [data, setData] = useState<SensorReadingResponse[]>([]);
     const [loading, setLoading] = useState(true);
 
@@ -131,3 +131,15 @@ export default function LiveGraph({ sensorId, metric, color = "#8884d8", label, 
         </div>
     );
 }
+
+export default React.memo(LiveGraph, (prevProps, nextProps) => {
+    return (
+        prevProps.sensorId === nextProps.sensorId &&
+        prevProps.metric === nextProps.metric &&
+        prevProps.color === nextProps.color &&
+        prevProps.label === nextProps.label &&
+        prevProps.height === nextProps.height &&
+        prevProps.variant === nextProps.variant &&
+        prevProps.yAxisLabel === nextProps.yAxisLabel
+    );
+});

--- a/web/src/components/LogsPanel.tsx
+++ b/web/src/components/LogsPanel.tsx
@@ -592,9 +592,22 @@ export default function LogsPanel({
                                         key={sensor.id}
                                         className={`side-panel-tab ${activeSensorId === sensor.id ? "active" : ""}`}
                                         onClick={() => setActiveSensorId(sensor.id)}
-                                        title={`${sensor.label} (${sensor.kind})`}
+                                        title={
+                                            sensor.config?.custom_label
+                                                ? `${sensor.config.custom_label} (${sensor.label || sensor.id}) (${sensor.kind})`
+                                                : `${sensor.label || sensor.id} (${sensor.kind})`
+                                        }
                                     >
-                                        {sensor.label || sensor.id}
+                                        {sensor.config?.custom_label ? (
+                                            <>
+                                                {sensor.config.custom_label}{" "}
+                                                <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.85em", fontWeight: "normal" }}>
+                                                    ({sensor.label || sensor.id})
+                                                </span>
+                                            </>
+                                        ) : (
+                                            sensor.label || sensor.id
+                                        )}
                                     </button>
                                 ))}
                             </div>
@@ -713,7 +726,21 @@ export default function LogsPanel({
                                             sensorLogs.map((row, idx) => (
                                                 <tr key={`${row.ts}-${row.sensor_id}-${row.metric}-${idx}`}>
                                                     <td className="logs-cell-time">{formatDateTime(row.ts)}</td>
-                                                    <td>{row.sensor_label || row.sensor_id}</td>
+                                                    <td>
+                                                        {(() => {
+                                                            const match = sensors.find(s => s.id === row.sensor_id);
+                                                            return match?.config?.custom_label ? (
+                                                                <>
+                                                                    {match.config.custom_label}{" "}
+                                                                    <span style={{ color: "var(--hmi-text-muted)", fontSize: "0.85em" }}>
+                                                                        ({row.sensor_label || row.sensor_id})
+                                                                    </span>
+                                                                </>
+                                                            ) : (
+                                                                row.sensor_label || row.sensor_id
+                                                            );
+                                                        })()}
+                                                    </td>
                                                     <td>{row.sensor_kind || "-"}</td>
                                                     <td>{row.metric}</td>
                                                     <td>{row.value.toFixed(4)}</td>


### PR DESCRIPTION
## Summary
This PR implements the ability to rename/add custom labels to Konica Minolta T-10A sensor heads and bodies directly from the HMI dashboard. The original hardware labels are preserved in parentheses next to the custom names for clarity.

## Type
- [x] Feature
- [ ] Fix
- [ ] Docs
- [ ] Chore

## Testing
Ran Automated Tests and manually tested

## Risk and rollout
Should be low risk, doesn't modify any core functionality, just a labeling change.
## Checklist
- [ ] Issue linked if applicable
- [ ] Added or updated docs
- [x] CI green
- [ ] At least one reviewer not the author
