### PR TITLE
Fix capped T-10A zero readings

### DIFF
--- a/svc/app/sensors/t10a_client.py
+++ b/svc/app/sensors/t10a_client.py
@@ -201,7 +201,11 @@ class T10AClient(SensorClient):
         Meters sometimes pad with spaces, e.g. '+ 2904' instead of '+02904'.
         """
         compact = field.replace(" ", "")
-        if not compact or compact[0] not in "+-":
+        if not compact:
+            return None
+        if compact.isdigit() and set(compact[:-1] or compact) <= {"0"}:
+            return 0.0
+        if compact[0] not in "+-":
             return None
         if len(compact) == 5:
             # '+2904' -> '+02904' (insert mantissa leading zero)
@@ -259,6 +263,17 @@ class T10AClient(SensorClient):
             m = re.search(r"[+-]?(?:\d+\.\d*|\d*\.\d+)", body)
             if m:
                 return float(m.group(0))
+
+            # Pattern 5: explicit scalar zero, e.g. "0 lx" from a capped sensor.
+            # Keep this after structured parsers so header/status digits are not mistaken for data.
+            m = re.search(r"(?<![\d.])([+-]?0(?:\.0+)?)(?![\d.])", body)
+            if m:
+                before = body[: m.start()].strip()
+                after = body[m.end() :].strip().lower()
+                has_label_prefix = not before or before.endswith(("=", ":"))
+                has_unit_suffix = after.startswith(("lx", "lux", "fcd"))
+                if has_label_prefix or has_unit_suffix or not after:
+                    return 0.0
 
             return None
         except Exception as e:

--- a/svc/tests/test_sqlite.py
+++ b/svc/tests/test_sqlite.py
@@ -36,6 +36,7 @@ from app.state import (
     save_groups,
     register_sensor,
     insert_sensor_reading,
+    fetch_latest_readings,
     fetch_sensor_log_entries,
     prune_sensors_to_ids,
     list_sensors,
@@ -776,6 +777,31 @@ class TestSensorLogOperations:
         assert len(rows) == 1
         assert rows[0]["metric"] == "ghi_w_m2"
         assert rows[0]["ts"] == 2002.0
+
+    def test_zero_sensor_reading_is_persisted_as_latest(self, temp_db):
+        """A legitimate zero reading should remain visible to connected-sensor checks."""
+        register_sensor(
+            sensor_id="KM1-00",
+            kind="t10a",
+            label="Desk center",
+            location="Desk",
+            config={"device_id": "KM1"},
+        )
+        insert_sensor_reading("KM1-00", 1000.0, "lux", 0.0)
+
+        latest = fetch_latest_readings()
+        assert latest == [
+            {
+                "sensor_id": "KM1-00",
+                "metric": "lux",
+                "value": 0.0,
+                "ts": 1000.0,
+            }
+        ]
+
+        rows = fetch_sensor_log_entries(limit=10, offset=0, sensor_id="KM1-00")
+        assert len(rows) == 1
+        assert rows[0]["value"] == 0.0
 
     def test_prune_sensors_to_ids_removes_stale_rows(self, temp_db):
         """Pruning should remove sensors and readings not in active config."""

--- a/svc/tests/test_t10a_client.py
+++ b/svc/tests/test_t10a_client.py
@@ -53,10 +53,23 @@ def test_parse_measurement_reply_t10a_fixed_field() -> None:
     assert client._parse_measurement_reply(head, reply) == 123.0
 
 
+def test_parse_measurement_reply_t10a_unsigned_zero_field() -> None:
+    client = _make_client_stub()
+    head = T10AHeadConfig(head_no=0, sensor_id="KMX-00", label="x")
+    reply = "\x02" + "00" + "10" + "0000" + "000004" + "      " + "      " + "\x03AA"
+    assert client._parse_measurement_reply(head, reply) == 0.0
+
+
 def test_parse_measurement_reply_decimal_fallback() -> None:
     client = _make_client_stub()
     head = T10AHeadConfig(head_no=0, sensor_id="KMX-00", label="x")
     assert client._parse_measurement_reply(head, "EV=67.9lx") == 67.9
+
+
+def test_parse_measurement_reply_plain_zero_with_unit() -> None:
+    client = _make_client_stub()
+    head = T10AHeadConfig(head_no=0, sensor_id="KMX-00", label="x")
+    assert client._parse_measurement_reply(head, "EV=0 lx") == 0.0
 
 
 def test_parse_measurement_reply_does_not_parse_header_integers() -> None:
@@ -71,3 +84,20 @@ def test_build_frame_contains_stx_etx_bcc() -> None:
     assert frame.startswith(b"\x02")
     assert b"\x03" in frame
     assert frame.endswith(b"\r\n")
+
+
+def test_poll_emits_zero_lux_reading(monkeypatch) -> None:
+    client = _make_client_stub()
+    head = T10AHeadConfig(head_no=0, sensor_id="KMX-00", label="x")
+    client.heads = [head]
+    client._measure_params = "0200"
+
+    reply = "\x02" + "00" + "10" + "0000" + "000004" + "      " + "      " + "\x03AA"
+    monkeypatch.setattr(client, "_send_command", lambda head_no, cmd, params: reply)
+
+    readings = list(client.poll())
+
+    assert len(readings) == 1
+    assert readings[0].sensor_id == "KMX-00"
+    assert readings[0].metric == "lux"
+    assert readings[0].value == 0.0

--- a/web/src/utils/sensorDisplay.test.ts
+++ b/web/src/utils/sensorDisplay.test.ts
@@ -15,10 +15,10 @@ const sensor = (id: string, interval_s?: number, kind = "t10a", label = id): Sen
     config: interval_s == null ? {} : { interval_s },
 });
 
-const reading = (sensor_id: string, metric: string, ts: number): SensorReadingResponse => ({
+const reading = (sensor_id: string, metric: string, ts: number, value = 1): SensorReadingResponse => ({
     sensor_id,
     metric,
-    value: 1,
+    value,
     ts,
 });
 
@@ -38,6 +38,14 @@ describe("sensorDisplay", () => {
         ];
 
         expect(connectedSensors(sensors, metrics, 1000).map(s => s.id)).toEqual(["fresh"]);
+    });
+
+    it("treats zero-valued fresh metrics as connected", () => {
+        const sensors = [sensor("capped", 10)];
+        const metrics = [reading("capped", "lux", 1000, 0)];
+
+        expect(getFreshMetricsForSensor(sensors[0], metrics, 1000)[0].value).toBe(0);
+        expect(connectedSensors(sensors, metrics, 1000).map(s => s.id)).toEqual(["capped"]);
     });
 
     it("filters stale metrics per sensor", () => {


### PR DESCRIPTION
## Summary
- Treats valid T-10A zero measurement frames as real `lux=0.0` readings.
- Ensures sensors connected with the lens cap on still report as connected after first poll.
- Keeps header/status-only replies from being mistaken for zero measurements.
- Adds backend regression coverage for zero readings being persisted and returned as latest metrics.
- Adds frontend regression coverage so fresh zero-valued metrics count as connected.

## Testing
- Ran `uv run pytest -q` from `svc`
- Ran `npm test` from `web`

## Risk and rollout
Risk is low because this is scoped to accepting valid zero sensor readings instead of dropping them. Existing non-zero parsing and stale/no-data behavior remain unchanged. Rollback plan is to revert this PR if T-10A readings parse incorrectly in the field.

## Checklist
- [ ] Issue linked if applicable
- [ ] Added or updated docs
- [x] CI green
- [ ] At least one reviewer not the author